### PR TITLE
fix(ci): Netlify prod env + finish Cursor Cloud setup notes

### DIFF
--- a/.github/workflows/web-deploy-netlify.yml
+++ b/.github/workflows/web-deploy-netlify.yml
@@ -31,6 +31,9 @@ jobs:
   build-and-deploy:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    # Prefer GitHub Environment secrets (Settings → Environments → production).
+    # Repository secrets still work as a fallback for the same names.
+    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,8 +62,12 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_MARKETING }}
         run: |
-          if [ -z "${NETLIFY_AUTH_TOKEN}" ] || [ -z "${NETLIFY_SITE_ID}" ]; then
-            echo "::warning::Skipping marketing deploy (missing NETLIFY_AUTH_TOKEN or NETLIFY_SITE_ID_MARKETING)"
+          if [ -z "${NETLIFY_AUTH_TOKEN}" ]; then
+            echo "::warning::Skipping marketing deploy (missing NETLIFY_AUTH_TOKEN)"
+            exit 0
+          fi
+          if [ -z "${NETLIFY_SITE_ID}" ]; then
+            echo "::warning::Skipping marketing deploy (missing NETLIFY_SITE_ID_MARKETING — Site ID from Netlify Site configuration)"
             exit 0
           fi
           netlify deploy --prod --dir=web/marketing/dist --message "gha ${{ github.sha }}"
@@ -70,8 +77,12 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_DOCS }}
         run: |
-          if [ -z "${NETLIFY_AUTH_TOKEN}" ] || [ -z "${NETLIFY_SITE_ID}" ]; then
-            echo "::warning::Skipping docs deploy (missing NETLIFY_AUTH_TOKEN or NETLIFY_SITE_ID_DOCS)"
+          if [ -z "${NETLIFY_AUTH_TOKEN}" ]; then
+            echo "::warning::Skipping docs deploy (missing NETLIFY_AUTH_TOKEN)"
+            exit 0
+          fi
+          if [ -z "${NETLIFY_SITE_ID}" ]; then
+            echo "::warning::Skipping docs deploy (missing NETLIFY_SITE_ID_DOCS — Site ID from Netlify Site configuration)"
             exit 0
           fi
           netlify deploy --prod --dir=web/docs/dist --message "gha ${{ github.sha }}"
@@ -81,8 +92,12 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_INSTALLER }}
         run: |
-          if [ -z "${NETLIFY_AUTH_TOKEN}" ] || [ -z "${NETLIFY_SITE_ID}" ]; then
-            echo "::warning::Skipping installer deploy (missing NETLIFY_AUTH_TOKEN or NETLIFY_SITE_ID_INSTALLER)"
+          if [ -z "${NETLIFY_AUTH_TOKEN}" ]; then
+            echo "::warning::Skipping installer deploy (missing NETLIFY_AUTH_TOKEN)"
+            exit 0
+          fi
+          if [ -z "${NETLIFY_SITE_ID}" ]; then
+            echo "::warning::Skipping installer deploy (missing NETLIFY_SITE_ID_INSTALLER — Site ID from Netlify Site configuration)"
             exit 0
           fi
           netlify deploy --prod --dir=web/installer/dist --message "gha ${{ github.sha }}"
@@ -92,8 +107,12 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_BRAND }}
         run: |
-          if [ -z "${NETLIFY_AUTH_TOKEN}" ] || [ -z "${NETLIFY_SITE_ID}" ]; then
-            echo "::warning::Skipping brand deploy (missing NETLIFY_AUTH_TOKEN or NETLIFY_SITE_ID_BRAND)"
+          if [ -z "${NETLIFY_AUTH_TOKEN}" ]; then
+            echo "::warning::Skipping brand deploy (missing NETLIFY_AUTH_TOKEN)"
+            exit 0
+          fi
+          if [ -z "${NETLIFY_SITE_ID}" ]; then
+            echo "::warning::Skipping brand deploy (missing NETLIFY_SITE_ID_BRAND — Site ID from Netlify Site configuration)"
             exit 0
           fi
           netlify deploy --prod --dir=web/brand-showcase/dist --message "gha ${{ github.sha }}"

--- a/.github/workflows/web-deploy-netlify.yml
+++ b/.github/workflows/web-deploy-netlify.yml
@@ -70,7 +70,8 @@ jobs:
             echo "::warning::Skipping marketing deploy (missing NETLIFY_SITE_ID_MARKETING — Site ID from Netlify Site configuration)"
             exit 0
           fi
-          netlify deploy --prod --dir=web/marketing/dist --message "gha ${{ github.sha }}"
+          # --filter avoids Netlify CLI monorepo project picker in CI
+          CI=true netlify deploy --prod --dir=web/marketing/dist --filter @ttnleipzig/regenfass-marketing --message "gha ${{ github.sha }}"
 
       - name: Deploy docs → docs.regenfass.eu
         env:
@@ -85,7 +86,7 @@ jobs:
             echo "::warning::Skipping docs deploy (missing NETLIFY_SITE_ID_DOCS — Site ID from Netlify Site configuration)"
             exit 0
           fi
-          netlify deploy --prod --dir=web/docs/dist --message "gha ${{ github.sha }}"
+          CI=true netlify deploy --prod --dir=web/docs/dist --filter @ttnleipzig/regenfass-docs-site --message "gha ${{ github.sha }}"
 
       - name: Deploy installer → install.regenfass.eu
         env:
@@ -100,7 +101,7 @@ jobs:
             echo "::warning::Skipping installer deploy (missing NETLIFY_SITE_ID_INSTALLER — Site ID from Netlify Site configuration)"
             exit 0
           fi
-          netlify deploy --prod --dir=web/installer/dist --message "gha ${{ github.sha }}"
+          CI=true netlify deploy --prod --dir=web/installer/dist --filter @ttnleipzig/regenfass-installer --message "gha ${{ github.sha }}"
 
       - name: Deploy brand showcase → brand.regenfass.eu
         env:
@@ -115,4 +116,4 @@ jobs:
             echo "::warning::Skipping brand deploy (missing NETLIFY_SITE_ID_BRAND — Site ID from Netlify Site configuration)"
             exit 0
           fi
-          netlify deploy --prod --dir=web/brand-showcase/dist --message "gha ${{ github.sha }}"
+          CI=true netlify deploy --prod --dir=web/brand-showcase/dist --filter @ttnleipzig/regenfass-brand-showcase --message "gha ${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 /web/**/playwright-report
 /web/**/blob-report
 /web/**/.vite
+/web/**/.netlify
 /web/**/tsconfig*.tsbuildinfo
 
 !/backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,16 +176,14 @@ chore(deps): bump vite in installer
 
 ## Cursor Cloud specific instructions
 
-- **Dependency refresh:** run `pnpm install` from the **repository root** (pnpm workspace). Do not assume a standalone `installer/` package at the repo root.
-- **Installer:** package at `web/installer`. Dev server: `pnpm dev:installer` or `pnpm --filter @ttnleipzig/regenfass-installer dev` or `cd web/installer && pnpm dev` (Vite default port **5173**).
-- **Brand showcase:** `pnpm dev:brand` → <http://localhost:5174>.
-- **Marketing:** `pnpm dev:marketing` → <http://localhost:5175>.
-- **Docs site:** `pnpm dev:docs` → <http://localhost:5176>.
-- **Lint / test (installer):** `pnpm lint` and `pnpm test` from root, or the same scripts inside `web/installer`.
-- **Web Serial:** full flash/configure E2E needs a **Chromium** browser and **physical USB hardware**. Unit tests and most Playwright smoke tests run without a board; do not block CI setup on hardware.
-- **Firmware** remains PlatformIO from the repo root (`pio run`); unrelated to the pnpm workspace.
-- Contributor technical docs live in `/docs` (flat files). Standard commands are also summarized in `docs/Local-Development.md` and `web/installer/README.md`.
-- **Netlify:** production deploys are via GitHub Actions (`.github/workflows/web-deploy-netlify.yml`) or CLI. Cursor secrets ≠ GitHub Actions secrets — GHA needs the same names under **Environments → production** (see `docs/Netlify-Deployment.md`). Local/CLI deploys in this monorepo need `CI=true` and `--filter <package>` or the CLI hangs on a project picker. Maton/Netlify MCP may still need separate Cursor auth; the CLI + token works without it.
+- **Node / pnpm:** Node 22+ works; pnpm is pinned via root `packageManager` (`pnpm@10.28.0`). Prefer Corepack (`corepack enable`) so installs match the lockfile.
+- **Dependency refresh:** run `pnpm install` from the **repository root** (pnpm workspace). There is **no** top-level `installer/` package — the app lives under `web/installer`.
+- **What must run for installer web work:** only the installer Vite app (`pnpm dev:installer` → **5173**). `@regenfass/brand` is a workspace library (no separate server). Backend/Postgres, PlatformIO firmware, marketing/docs/brand-showcase are optional for installer UI work.
+- **Other web apps (optional):** `pnpm dev:brand` → 5174, `pnpm dev:marketing` → 5175, `pnpm dev:docs` → 5176.
+- **Lint / test / build:** from root — `pnpm lint`, `pnpm test`, `pnpm build:installer` (or `pnpm build` for all web packages). Details also in `docs/Local-Development.md` and `web/installer/README.md`.
+- **Web Serial:** full flash/configure E2E needs **Chromium** and **physical USB hardware**. Unit tests run without a board; do not block setup on hardware.
+- **Firmware:** PlatformIO from repo root (`pio run`); unrelated to the pnpm workspace. Not required for installer web setup.
+- **Netlify:** GitHub Actions builds + `netlify deploy` (see `docs/Netlify-Deployment.md`). Cursor secrets ≠ GitHub Actions secrets — GHA reads **Environments → production**. CLI deploys in this monorepo need `CI=true` and `--filter <package>` or the CLI hangs on a project picker.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ chore(deps): bump vite in installer
 - **Web Serial:** full flash/configure E2E needs a **Chromium** browser and **physical USB hardware**. Unit tests and most Playwright smoke tests run without a board; do not block CI setup on hardware.
 - **Firmware** remains PlatformIO from the repo root (`pio run`); unrelated to the pnpm workspace.
 - Contributor technical docs live in `/docs` (flat files). Standard commands are also summarized in `docs/Local-Development.md` and `web/installer/README.md`.
+- **Netlify:** production deploys are via GitHub Actions (`.github/workflows/web-deploy-netlify.yml`) or CLI. Cursor secrets ≠ GitHub Actions secrets — GHA needs the same names under **Environments → production** (see `docs/Netlify-Deployment.md`). Local/CLI deploys in this monorepo need `CI=true` and `--filter <package>` or the CLI hangs on a project picker. Maton/Netlify MCP may still need separate Cursor auth; the CLI + token works without it.
 
 ---
 

--- a/docs/Netlify-Deployment.md
+++ b/docs/Netlify-Deployment.md
@@ -62,6 +62,8 @@ Each app has `public/_redirects` (`/* → /index.html` 200) so client-side route
 
 ## GitHub secrets checklist
 
+Add these under **Settings → Environments → `production`** (preferred — the deploy workflow uses that environment) or as repository secrets.
+
 | Secret | Purpose |
 |--------|---------|
 | `NETLIFY_AUTH_TOKEN` | Authenticate `netlify deploy` |
@@ -70,7 +72,7 @@ Each app has `public/_redirects` (`/* → /index.html` 200) so client-side route
 | `NETLIFY_SITE_ID_INSTALLER` | Installer site ID |
 | `NETLIFY_SITE_ID_BRAND` | Brand showcase site ID |
 
-Missing secrets log a warning and skip that site; the job still succeeds so you can roll out sites one by one.
+A present auth token with a missing Site ID only skips that site (warning in the Actions log). The job can still be green — check the annotations, not just the check mark.
 
 ## Manual / local deploy
 

--- a/docs/Netlify-Deployment.md
+++ b/docs/Netlify-Deployment.md
@@ -76,14 +76,31 @@ A present auth token with a missing Site ID only skips that site (warning in the
 
 ## Manual / local deploy
 
+Build first, then deploy the already-built `dist/` (do not let the CLI rebuild). In this monorepo you **must** pass `--filter` so the CLI does not hang on an interactive project picker:
+
 ```bash
 corepack enable && pnpm install
 pnpm build:docs   # or :marketing / :installer / :brand
 
 export NETLIFY_AUTH_TOKEN=…
 export NETLIFY_SITE_ID=…   # that site’s ID
-npx netlify-cli deploy --prod --dir=web/docs/dist
+CI=true npx netlify-cli@23 deploy --prod --dir=web/docs/dist \
+  --filter @ttnleipzig/regenfass-docs-site
 ```
+
+| App | `--dir` | `--filter` |
+|-----|---------|------------|
+| Marketing | `web/marketing/dist` | `@ttnleipzig/regenfass-marketing` |
+| Docs | `web/docs/dist` | `@ttnleipzig/regenfass-docs-site` |
+| Installer | `web/installer/dist` | `@ttnleipzig/regenfass-installer` |
+| Brand | `web/brand-showcase/dist` | `@ttnleipzig/regenfass-brand-showcase` |
+
+Production Netlify hostnames (until custom domains are attached):
+
+- <https://regenfass-marketing.netlify.app>
+- <https://regenfass-docs.netlify.app>
+- <https://regenfass-installer.netlify.app>
+- <https://regenfass-brand.netlify.app>
 
 ## Fallback build command (if you must build on Netlify)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Finishes Cloud Agent environment guidance alongside the Netlify deploy workflow fixes.

Earlier `Web Deploy Netlify` runs on `main` were green but **skipped** every site (missing Site IDs / secrets not bound to `production`).

## Env setup (verified in this agent)

| Check | Result |
|-------|--------|
| Update script | `corepack enable` + `pnpm install` (submitted) |
| `pnpm lint` | pass |
| `pnpm test` | 60 files / 532 tests pass |
| `pnpm dev:installer` | http://localhost:5173 — welcome → Next → Web Serial dialog |

## Netlify (CLI verified with Cursor secrets)

| Site | URL |
|------|-----|
| marketing | https://regenfass-marketing.netlify.app |
| docs | https://regenfass-docs.netlify.app |
| installer | https://regenfass-installer.netlify.app |
| brand | https://regenfass-brand.netlify.app |

**Still separate:** GitHub Environment `production` must hold the same five secrets for Actions (Cursor secrets ≠ GHA). Custom domains not attached yet.

## Change

- Bind deploy job to `environment: production`
- Clearer skip warnings; `CI=true` + `--filter` for monorepo CLI
- Docs / AGENTS Cloud notes; ignore `web/**/.netlify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93b4b604-e3f6-484f-a332-82daf04071ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93b4b604-e3f6-484f-a332-82daf04071ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

