### PR TITLE
fix(release): sync firmware version with Release Please

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -38,7 +38,8 @@
           "path": "web/docs/package.json",
           "jsonpath": "$.version"
         },
-        "web/brand/src/version.ts"
+        "web/brand/src/version.ts",
+        "src/version.h"
       ]
     }
   }

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -11,6 +11,7 @@ Regenfass uses a **single semver** for firmware and all web apps. Source of trut
 | `CHANGELOG.md` | Human-readable release notes |
 | `package.json` + `web/*/package.json` | Same `version` field (synced on release) |
 | `web/brand/src/version.ts` | `APP_VERSION` shown in every web app footer |
+| `src/version.h` | `REGENFASS_VERSION` for firmware serial/SCP |
 
 Release Please bumps **all of these together** when the release PR merges (see `extra-files` in `.release-please-config.json`).
 
@@ -31,7 +32,7 @@ Breaking changes: `BREAKING CHANGE:` footer or `!` after type/scope.
 
 1. Branch from `main` (for example `feature/…`).
 2. Open a PR; address review; merge (squash preferred).
-3. Release Please opens or updates a **release PR** collecting conventional commits. That PR updates `CHANGELOG.md`, `version.txt`, the manifest, package versions, and `APP_VERSION`.
+3. Release Please opens or updates a **release PR** collecting conventional commits. That PR updates `CHANGELOG.md`, `version.txt`, the manifest, package versions, `APP_VERSION`, and `REGENFASS_VERSION`.
 4. Merge the release PR to create the **git tag** and a **GitHub Release** whose body is the new changelog section.
 
 ```mermaid

--- a/platformio.ini
+++ b/platformio.ini
@@ -73,7 +73,6 @@ build_flags =
 	-D SENSOR_MAX_DISTANCE=40
 	-std=c++17
 	-std=gnu++17
-	; -D REGENFASS_VERSION='"0.0.1"'
 build_unflags =
 	-std=gnu++11
 	-std=gnu++14

--- a/src/version.h
+++ b/src/version.h
@@ -2,7 +2,7 @@
 #define REGENFASS_H
 
 #ifndef REGENFASS_VERSION
-#define REGENFASS_VERSION "development"
+#define REGENFASS_VERSION "0.1.0" // x-release-please-version
 #endif
 
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining gap in the unified Release Please versioning: firmware now shares the same semver as the web apps.

- Set `REGENFASS_VERSION` in `src/version.h` to `0.1.0` with an `x-release-please-version` marker
- Add `src/version.h` to Release Please `extra-files`
- Drop the obsolete commented PlatformIO `-D REGENFASS_VERSION` override
- Document `src/version.h` in `docs/Release-Process.md`

## Verification

- `pnpm --filter @ttnleipzig/regenfass-marketing build` succeeds; root `CHANGELOG.md` is still embedded via `?raw` (no Vite config change needed)
- `.release-please-config.json` remains valid JSON

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d05010cf-befd-4ea0-af75-797bba932282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d05010cf-befd-4ea0-af75-797bba932282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

