### PR TITLE
feat(web): add Swetrix analytics across Vite apps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 # Swetrix Admin API (for scripts/provision-swetrix.mjs)
 SWETRIX_API_KEY=
-# Admin API host (Cloud default). Self-hosted CE: https://your-host/backend
+# Admin API host. Cloud: https://api.swetrix.com
+# Self-hosted CE API example: https://analytics-api.example.com
 SWETRIX_BASE_URL=https://api.swetrix.com
-# Events API log URL for the browser SDK (optional on Cloud).
-# Self-hosted CE example: https://your-host/backend/log
+# Browser Events API log URL (optional on Cloud).
+# Self-hosted CE example: https://analytics-api.example.com/log
 SWETRIX_API_URL=
 
 # One project ID per web app (no VITE_ prefix here).

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
-# Swetrix Admin API (optional — for scripts/provision-swetrix.mjs)
+# Swetrix Admin API (for scripts/provision-swetrix.mjs)
 SWETRIX_API_KEY=
+# Admin API host (Cloud default). Self-hosted CE: https://your-host/backend
+SWETRIX_BASE_URL=https://api.swetrix.com
+# Events API log URL for the browser SDK (optional on Cloud).
+# Self-hosted CE example: https://your-host/backend/log
+SWETRIX_API_URL=
 
 # One project ID per web app (no VITE_ prefix here).
 # Sync into each Vite app with: node scripts/sync-swetrix-env.mjs

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Swetrix Admin API (optional — for scripts/provision-swetrix.mjs)
+SWETRIX_API_KEY=
+
+# One project ID per web app (no VITE_ prefix here).
+# Sync into each Vite app with: node scripts/sync-swetrix-env.mjs
+SWETRIX_PROJECT_ID_INSTALLER=
+SWETRIX_PROJECT_ID_MARKETING=
+SWETRIX_PROJECT_ID_DOCS=
+SWETRIX_PROJECT_ID_BRAND=

--- a/.github/workflows/web-deploy-netlify.yml
+++ b/.github/workflows/web-deploy-netlify.yml
@@ -53,10 +53,10 @@ jobs:
 
       - name: Write Swetrix project IDs for Vite builds
         env:
-          VITE_SWETRIX_PROJECT_ID_INSTALLER: ${{ secrets.VITE_SWETRIX_PROJECT_ID_INSTALLER }}
-          VITE_SWETRIX_PROJECT_ID_MARKETING: ${{ secrets.VITE_SWETRIX_PROJECT_ID_MARKETING }}
-          VITE_SWETRIX_PROJECT_ID_DOCS: ${{ secrets.VITE_SWETRIX_PROJECT_ID_DOCS }}
-          VITE_SWETRIX_PROJECT_ID_BRAND: ${{ secrets.VITE_SWETRIX_PROJECT_ID_BRAND }}
+          SWETRIX_PROJECT_ID_INSTALLER: ${{ secrets.SWETRIX_PROJECT_ID_INSTALLER }}
+          SWETRIX_PROJECT_ID_MARKETING: ${{ secrets.SWETRIX_PROJECT_ID_MARKETING }}
+          SWETRIX_PROJECT_ID_DOCS: ${{ secrets.SWETRIX_PROJECT_ID_DOCS }}
+          SWETRIX_PROJECT_ID_BRAND: ${{ secrets.SWETRIX_PROJECT_ID_BRAND }}
         run: |
           write_env() {
             local dir="$1"
@@ -68,10 +68,10 @@ jobs:
               echo "::notice::Skipping $dir/.env (secret empty — analytics disabled for that app build)"
             fi
           }
-          write_env web/installer "$VITE_SWETRIX_PROJECT_ID_INSTALLER"
-          write_env web/marketing "$VITE_SWETRIX_PROJECT_ID_MARKETING"
-          write_env web/docs "$VITE_SWETRIX_PROJECT_ID_DOCS"
-          write_env web/brand-showcase "$VITE_SWETRIX_PROJECT_ID_BRAND"
+          write_env web/installer "$SWETRIX_PROJECT_ID_INSTALLER"
+          write_env web/marketing "$SWETRIX_PROJECT_ID_MARKETING"
+          write_env web/docs "$SWETRIX_PROJECT_ID_DOCS"
+          write_env web/brand-showcase "$SWETRIX_PROJECT_ID_BRAND"
 
       - name: Build web packages
         run: pnpm -r --filter "./web/**" --if-present run build

--- a/.github/workflows/web-deploy-netlify.yml
+++ b/.github/workflows/web-deploy-netlify.yml
@@ -57,12 +57,18 @@ jobs:
           SWETRIX_PROJECT_ID_MARKETING: ${{ secrets.SWETRIX_PROJECT_ID_MARKETING }}
           SWETRIX_PROJECT_ID_DOCS: ${{ secrets.SWETRIX_PROJECT_ID_DOCS }}
           SWETRIX_PROJECT_ID_BRAND: ${{ secrets.SWETRIX_PROJECT_ID_BRAND }}
+          SWETRIX_API_URL: ${{ secrets.SWETRIX_API_URL }}
         run: |
           write_env() {
             local dir="$1"
             local value="$2"
             if [ -n "$value" ]; then
-              printf 'VITE_SWETRIX_PROJECT_ID=%s\n' "$value" > "$dir/.env"
+              {
+                printf 'VITE_SWETRIX_PROJECT_ID=%s\n' "$value"
+                if [ -n "${SWETRIX_API_URL}" ]; then
+                  printf 'VITE_SWETRIX_API_URL=%s\n' "$SWETRIX_API_URL"
+                fi
+              } > "$dir/.env"
               echo "Wrote $dir/.env"
             else
               echo "::notice::Skipping $dir/.env (secret empty — analytics disabled for that app build)"

--- a/.github/workflows/web-deploy-netlify.yml
+++ b/.github/workflows/web-deploy-netlify.yml
@@ -51,6 +51,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Write Swetrix project IDs for Vite builds
+        env:
+          VITE_SWETRIX_PROJECT_ID_INSTALLER: ${{ secrets.VITE_SWETRIX_PROJECT_ID_INSTALLER }}
+          VITE_SWETRIX_PROJECT_ID_MARKETING: ${{ secrets.VITE_SWETRIX_PROJECT_ID_MARKETING }}
+          VITE_SWETRIX_PROJECT_ID_DOCS: ${{ secrets.VITE_SWETRIX_PROJECT_ID_DOCS }}
+          VITE_SWETRIX_PROJECT_ID_BRAND: ${{ secrets.VITE_SWETRIX_PROJECT_ID_BRAND }}
+        run: |
+          write_env() {
+            local dir="$1"
+            local value="$2"
+            if [ -n "$value" ]; then
+              printf 'VITE_SWETRIX_PROJECT_ID=%s\n' "$value" > "$dir/.env"
+              echo "Wrote $dir/.env"
+            else
+              echo "::notice::Skipping $dir/.env (secret empty — analytics disabled for that app build)"
+            fi
+          }
+          write_env web/installer "$VITE_SWETRIX_PROJECT_ID_INSTALLER"
+          write_env web/marketing "$VITE_SWETRIX_PROJECT_ID_MARKETING"
+          write_env web/docs "$VITE_SWETRIX_PROJECT_ID_DOCS"
+          write_env web/brand-showcase "$VITE_SWETRIX_PROJECT_ID_BRAND"
+
       - name: Build web packages
         run: pnpm -r --filter "./web/**" --if-present run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 !/pnpm-workspace.yaml
 !/pnpm-lock.yaml
 !/netlify.toml
+!/scripts
+!/scripts/**
 
 !/web
 /web/**/node_modules
@@ -42,6 +44,7 @@
 /web/**/blob-report
 /web/**/.vite
 /web/**/.netlify
+/web/**/.env
 /web/**/tsconfig*.tsbuildinfo
 
 !/backend

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !/CONTRIBUTING.md
 !/.gitignore
 !/.editorconfig
+!/.env.example
 !/.releaserc.yml
 !/.markdownlintignore
 !/.release-please-config.json

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -83,7 +83,17 @@ SWETRIX_PROJECT_ID_DOCS=…
 SWETRIX_PROJECT_ID_BRAND=…
 ```
 
-Then sync them into each app as `VITE_SWETRIX_PROJECT_ID` (Vite only exposes `VITE_*` to the browser):
+Optional (self-hosted Community Edition):
+
+```env
+# Admin API host for scripts/provision-swetrix.mjs
+SWETRIX_BASE_URL=https://your-host/backend
+# Browser Events API (passed through as VITE_SWETRIX_API_URL)
+SWETRIX_API_URL=https://your-host/backend/log
+SWETRIX_API_KEY=…
+```
+
+Then sync them into each app as `VITE_SWETRIX_PROJECT_ID` (and optional `VITE_SWETRIX_API_URL`):
 
 ```bash
 node scripts/sync-swetrix-env.mjs
@@ -93,7 +103,13 @@ If `VITE_SWETRIX_PROJECT_ID` is empty or missing in an app, tracking for that ap
 
 Shared helpers live in `@regenfass/brand` (`initAnalytics`, `trackEvent`). Theme toggles emit `theme_toggled`; the installer emits `installer_state_<StateName>` on XState transitions; marketing CTAs emit `navigate_to_docs` / `navigate_to_installer`.
 
-### Funnels (create in the Swetrix dashboard)
+### Funnels
+
+Step definitions live in [`scripts/swetrix-funnels.json`](../scripts/swetrix-funnels.json). Create them in the Swetrix dashboard (**Funnels**) or via Admin API:
+
+```bash
+node scripts/provision-swetrix.mjs
+```
 
 **Installer** project — funnel name `Flash and configure` (event steps, in order):
 
@@ -111,12 +127,6 @@ Shared helpers live in `@regenfass/brand` (`initAnalytics`, `trackEvent`). Theme
 
 - `Path to documentation`: page `/` → event `navigate_to_docs`
 - `Path to installer`: page `/` → event `navigate_to_installer`
-
-With a valid Admin API key (`SWETRIX_API_KEY`), you can also run:
-
-```bash
-node scripts/provision-swetrix.mjs
-```
 
 ## SolidJS reminder
 

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -72,6 +72,19 @@ Flashing and live device configuration require:
 
 Unit tests and most Playwright smoke tests run without hardware. Full “hello world” flash flows are hardware-bound.
 
+## Analytics (Swetrix)
+
+Each Vite app under `web/` uses its own Swetrix project. Copy `web/<app>/.env.example` to `web/<app>/.env` and set `VITE_SWETRIX_PROJECT_ID`. If the variable is empty or missing, tracking stays disabled (safe for local work).
+
+Shared helpers live in `@regenfass/brand` (`initAnalytics`, `trackEvent`). Theme toggles emit `theme_toggled`; the installer emits `installer_state_<StateName>` on XState transitions; marketing CTAs emit `navigate_to_docs` / `navigate_to_installer`.
+
+To create projects and funnels with a personal Admin API key (same endpoints as the Swetrix MCP):
+
+```bash
+# set SWETRIX_API_KEY in the environment or root .env
+node scripts/provision-swetrix.mjs
+```
+
 ## SolidJS reminder
 
 Installer and brand UIs use **SolidJS only** — do not introduce React.

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -74,14 +74,47 @@ Unit tests and most Playwright smoke tests run without hardware. Full “hello w
 
 ## Analytics (Swetrix)
 
-Each Vite app under `web/` uses its own Swetrix project. Copy `web/<app>/.env.example` to `web/<app>/.env` and set `VITE_SWETRIX_PROJECT_ID`. If the variable is empty or missing, tracking stays disabled (safe for local work).
+Each Vite app under `web/` uses its own Swetrix project. Put the IDs in the **repository root** `.env` (no `VITE_` prefix):
+
+```env
+SWETRIX_PROJECT_ID_INSTALLER=…
+SWETRIX_PROJECT_ID_MARKETING=…
+SWETRIX_PROJECT_ID_DOCS=…
+SWETRIX_PROJECT_ID_BRAND=…
+```
+
+Then sync them into each app as `VITE_SWETRIX_PROJECT_ID` (Vite only exposes `VITE_*` to the browser):
+
+```bash
+node scripts/sync-swetrix-env.mjs
+```
+
+If `VITE_SWETRIX_PROJECT_ID` is empty or missing in an app, tracking for that app stays disabled.
 
 Shared helpers live in `@regenfass/brand` (`initAnalytics`, `trackEvent`). Theme toggles emit `theme_toggled`; the installer emits `installer_state_<StateName>` on XState transitions; marketing CTAs emit `navigate_to_docs` / `navigate_to_installer`.
 
-To create projects and funnels with a personal Admin API key (same endpoints as the Swetrix MCP):
+### Funnels (create in the Swetrix dashboard)
+
+**Installer** project — funnel name `Flash and configure` (event steps, in order):
+
+1. `installer_state_Start_WaitingForUser`
+2. `installer_state_Connect_Connecting`
+3. `installer_state_Connect_ReadingVersion`
+4. `installer_state_Install_WaitingForInstallationMethodChoice`
+5. `installer_state_Install_Installing`
+6. `installer_state_Install_MigratingConfiguration`
+7. `installer_state_Config_Editing`
+8. `installer_state_Config_WritingConfiguration`
+9. `installer_state_Finish_ShowingNextSteps`
+
+**Marketing** project:
+
+- `Path to documentation`: page `/` → event `navigate_to_docs`
+- `Path to installer`: page `/` → event `navigate_to_installer`
+
+With a valid Admin API key (`SWETRIX_API_KEY`), you can also run:
 
 ```bash
-# set SWETRIX_API_KEY in the environment or root .env
 node scripts/provision-swetrix.mjs
 ```
 

--- a/docs/Netlify-Deployment.md
+++ b/docs/Netlify-Deployment.md
@@ -72,6 +72,28 @@ Add these under **Settings → Environments → `production`** (preferred — th
 | `NETLIFY_SITE_ID_INSTALLER` | Installer site ID |
 | `NETLIFY_SITE_ID_BRAND` | Brand showcase site ID |
 
+### Swetrix analytics (build-time env)
+
+Each site needs its **own** Swetrix project ID at build time (Vite inlines `import.meta.env.VITE_*`). Set these as Netlify site environment variables (Site configuration → Environment variables), not GitHub secrets:
+
+| Netlify site | Variable | Value |
+|--------------|----------|-------|
+| Marketing | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `regenfass.eu` |
+| Docs | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `docs.regenfass.eu` |
+| Installer | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `install.regenfass.eu` |
+| Brand | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `brand.regenfass.eu` |
+
+Because production builds run in **GitHub Actions**, set these repository or `production` environment secrets (injected before `pnpm build`):
+
+| Secret | App |
+|--------|-----|
+| `VITE_SWETRIX_PROJECT_ID_MARKETING` | Marketing |
+| `VITE_SWETRIX_PROJECT_ID_DOCS` | Docs |
+| `VITE_SWETRIX_PROJECT_ID_INSTALLER` | Installer |
+| `VITE_SWETRIX_PROJECT_ID_BRAND` | Brand showcase |
+
+Locally, copy each `web/<app>/.env.example` to `.env` and fill in the ID, or run `node scripts/provision-swetrix.mjs` with a valid `SWETRIX_API_KEY`.
+
 A present auth token with a missing Site ID only skips that site (warning in the Actions log). The job can still be green — check the annotations, not just the check mark.
 
 ## Manual / local deploy

--- a/docs/Netlify-Deployment.md
+++ b/docs/Netlify-Deployment.md
@@ -82,6 +82,7 @@ Each site needs its **own** Swetrix project ID at build time (Vite inlines `impo
 | `SWETRIX_PROJECT_ID_DOCS` | Docs |
 | `SWETRIX_PROJECT_ID_INSTALLER` | Installer |
 | `SWETRIX_PROJECT_ID_BRAND` | Brand showcase |
+| `SWETRIX_API_URL` | Optional. Self-hosted Events API log URL (e.g. `https://analytics-api.example.com/log`). Omit for Swetrix Cloud. |
 
 Locally, put the same names in the repository root `.env`, then run `node scripts/sync-swetrix-env.mjs`.
 

--- a/docs/Netlify-Deployment.md
+++ b/docs/Netlify-Deployment.md
@@ -74,25 +74,16 @@ Add these under **Settings → Environments → `production`** (preferred — th
 
 ### Swetrix analytics (build-time env)
 
-Each site needs its **own** Swetrix project ID at build time (Vite inlines `import.meta.env.VITE_*`). Set these as Netlify site environment variables (Site configuration → Environment variables), not GitHub secrets:
-
-| Netlify site | Variable | Value |
-|--------------|----------|-------|
-| Marketing | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `regenfass.eu` |
-| Docs | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `docs.regenfass.eu` |
-| Installer | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `install.regenfass.eu` |
-| Brand | `VITE_SWETRIX_PROJECT_ID` | Swetrix project ID for `brand.regenfass.eu` |
-
-Because production builds run in **GitHub Actions**, set these repository or `production` environment secrets (injected before `pnpm build`):
+Each site needs its **own** Swetrix project ID at build time (Vite inlines `import.meta.env.VITE_*`). Because production builds run in **GitHub Actions**, set these repository or `production` environment secrets (written into each app’s `.env` as `VITE_SWETRIX_PROJECT_ID` before `pnpm build`):
 
 | Secret | App |
 |--------|-----|
-| `VITE_SWETRIX_PROJECT_ID_MARKETING` | Marketing |
-| `VITE_SWETRIX_PROJECT_ID_DOCS` | Docs |
-| `VITE_SWETRIX_PROJECT_ID_INSTALLER` | Installer |
-| `VITE_SWETRIX_PROJECT_ID_BRAND` | Brand showcase |
+| `SWETRIX_PROJECT_ID_MARKETING` | Marketing |
+| `SWETRIX_PROJECT_ID_DOCS` | Docs |
+| `SWETRIX_PROJECT_ID_INSTALLER` | Installer |
+| `SWETRIX_PROJECT_ID_BRAND` | Brand showcase |
 
-Locally, copy each `web/<app>/.env.example` to `.env` and fill in the ID, or run `node scripts/provision-swetrix.mjs` with a valid `SWETRIX_API_KEY`.
+Locally, put the same names in the repository root `.env`, then run `node scripts/sync-swetrix-env.mjs`.
 
 A present auth token with a missing Site ID only skips that site (warning in the Actions log). The job can still be green — check the annotations, not just the check mark.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       solid-icons:
         specifier: ^1.1.0
         version: 1.2.0(solid-js@1.9.14)
+      swetrix:
+        specifier: ^4.4.0
+        version: 4.4.0
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.6.0
@@ -74,10 +77,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.8
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
 
   web/docs:
     dependencies:
@@ -305,10 +308,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.8
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -885,6 +888,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rrweb/types@2.1.0':
+    resolution: {integrity: sha512-svOHkcuukP6rIjz2umwVsS7uYct+2h0N97+bg+8IJYKIUj5+YjwIvqx5y9NILFKPIu3yk+Mb+KDFfJ8RV+4JlA==}
+
+  '@rrweb/utils@2.1.0':
+    resolution: {integrity: sha512-hU7MT3TSdD+Do7FmMoHrBfPevFCheN5vo2mn97Y4vbXuwemopAmo8dqo5KJeMaA6oQQt7FinHJ0Xqb7k68Ci6Q==}
+
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
     engines: {node: '>=18'}
@@ -1015,6 +1024,9 @@ packages:
   '@types/crypto-js@4.2.2':
     resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1087,6 +1099,9 @@ packages:
 
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
 
   '@xstate/solid@2.0.0':
     resolution: {integrity: sha512-ycGMMJWPtfnc+CGhUxxe664wTVr4M2NXEJx4EsShbcT5G0d2bP378AtAsVvVhSjr6W5+7Br6htDivND1I6DOfQ==}
@@ -1191,6 +1206,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   baseline-browser-mapping@2.10.43:
     resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
@@ -1994,6 +2013,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -2239,8 +2261,17 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrdom@2.1.0:
+    resolution: {integrity: sha512-d7oaIHzwffxI74UJMZDGq/f97/Yfm3QX4CcTIlQelt2HsLavItLjp8x8nQ0g9Pet5+5wG1RGr9yvsxb1gJlo8A==}
+
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  rrweb-snapshot@2.1.0:
+    resolution: {integrity: sha512-CFjUKWlO+Dl72gk8qwcDcNE/Pj9yr6IvGRAiRAx12pmJaSWaOKFoFgpQQ1j/mW0WKwEZXbHnMJL8M92gIsdwUQ==}
+
+  rrweb@2.0.1:
+    resolution: {integrity: sha512-MQYzOtI7aZft9ffDMT6rmRSAj6hO4W6T7iA4eB9Mtcuiv3M7DbnnxDMrcPW0sQXepgYN46YhfSKe75d/mlUHrQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2399,6 +2430,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swetrix@4.4.0:
+    resolution: {integrity: sha512-UHQYER6tNHoM25mPw8rRkNRZts0xvUyPQXUzxW2C/nBBD5MxUjhsWqKhuuWjjgUn+nJ4Kl9Y0QsY/m50ryWWEA==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3224,6 +3258,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@rrweb/types@2.1.0': {}
+
+  '@rrweb/utils@2.1.0': {}
+
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
@@ -3381,6 +3419,8 @@ snapshots:
 
   '@types/crypto-js@4.2.2': {}
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3477,6 +3517,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@xstate/fsm@1.6.5': {}
+
   '@xstate/solid@2.0.0(solid-js@1.9.14)(xstate@5.32.5)':
     dependencies:
       solid-js: 1.9.14
@@ -3569,6 +3611,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   baseline-browser-mapping@2.10.43: {}
 
@@ -4452,6 +4496,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mitt@3.0.1: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -4685,7 +4731,26 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rrdom@2.1.0:
+    dependencies:
+      rrweb-snapshot: 2.1.0
+
   rrweb-cssom@0.8.0: {}
+
+  rrweb-snapshot@2.1.0:
+    dependencies:
+      postcss: 8.5.19
+
+  rrweb@2.0.1:
+    dependencies:
+      '@rrweb/types': 2.1.0
+      '@rrweb/utils': 2.1.0
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+      rrdom: 2.1.0
+      rrweb-snapshot: 2.1.0
 
   run-parallel@1.2.0:
     dependencies:
@@ -4840,6 +4905,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swetrix@4.4.0:
+    dependencies:
+      rrweb: 2.0.1
 
   symbol-tree@3.2.4: {}
 

--- a/scripts/provision-swetrix.mjs
+++ b/scripts/provision-swetrix.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Provision Swetrix projects and funnels via the Admin API
+ * (same endpoints as mcp-swetrix admin tools).
+ *
+ * Usage (from repo root):
+ *   node scripts/provision-swetrix.mjs
+ *
+ * Requires SWETRIX_API_KEY in the environment or /workspace/.env / .env.
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const BASE = process.env.SWETRIX_BASE_URL || "https://api.swetrix.com";
+
+function loadApiKey() {
+  if (process.env.SWETRIX_API_KEY?.trim()) return process.env.SWETRIX_API_KEY.trim();
+  for (const rel of [".env", "web/.env"]) {
+    const p = resolve(ROOT, rel);
+    if (!existsSync(p)) continue;
+    const text = readFileSync(p, "utf8");
+    const m = text.match(/^SWETRIX_API_KEY=(.+)$/m);
+    if (m) return m[1].trim().replace(/^["']|["']$/g, "");
+  }
+  throw new Error("SWETRIX_API_KEY not found in env or .env");
+}
+
+async function api(method, path, body, apiKey) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Api-Key": apiKey,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text;
+  }
+  if (!res.ok) {
+    const err = new Error(`Swetrix ${method} ${path} failed: ${res.status} ${text}`);
+    err.status = res.status;
+    err.data = data;
+    throw err;
+  }
+  return data;
+}
+
+const PROJECTS = [
+  {
+    name: "regenfass-installer",
+    origins: ["install.regenfass.eu"],
+    envPath: "web/installer/.env",
+  },
+  {
+    name: "regenfass-marketing",
+    origins: ["regenfass.eu"],
+    envPath: "web/marketing/.env",
+  },
+  {
+    name: "regenfass-docs",
+    origins: ["docs.regenfass.eu"],
+    envPath: "web/docs/.env",
+  },
+  {
+    name: "regenfass-brand",
+    origins: ["brand.regenfass.eu"],
+    envPath: "web/brand-showcase/.env",
+  },
+];
+
+const INSTALLER_FUNNEL_STEPS = [
+  "installer_state_Start_WaitingForUser",
+  "installer_state_Connect_Connecting",
+  "installer_state_Connect_ReadingVersion",
+  "installer_state_Install_WaitingForInstallationMethodChoice",
+  "installer_state_Install_Installing",
+  "installer_state_Install_MigratingConfiguration",
+  "installer_state_Config_Editing",
+  "installer_state_Config_WritingConfiguration",
+  "installer_state_Finish_ShowingNextSteps",
+];
+
+function writeEnvPid(relPath, pid) {
+  const abs = resolve(ROOT, relPath);
+  const line = `VITE_SWETRIX_PROJECT_ID=${pid}\n`;
+  if (existsSync(abs)) {
+    const prev = readFileSync(abs, "utf8");
+    if (/^VITE_SWETRIX_PROJECT_ID=/m.test(prev)) {
+      writeFileSync(
+        abs,
+        prev.replace(/^VITE_SWETRIX_PROJECT_ID=.*$/m, `VITE_SWETRIX_PROJECT_ID=${pid}`),
+      );
+      return;
+    }
+    writeFileSync(abs, prev.endsWith("\n") ? `${prev}${line}` : `${prev}\n${line}`);
+    return;
+  }
+  writeFileSync(abs, line);
+}
+
+function projectIdOf(row) {
+  return row?.id ?? row?.pid ?? row?.projectId;
+}
+
+async function ensureProject(apiKey, name, origins) {
+  const list = await api("GET", "/v1/project", undefined, apiKey);
+  const rows = Array.isArray(list) ? list : list?.results ?? list?.data ?? [];
+  const existing = rows.find((p) => p?.name === name);
+  if (existing) {
+    const id = projectIdOf(existing);
+    console.log(`reuse project ${name} → ${id}`);
+    if (origins?.length) {
+      try {
+        await api("PUT", `/v1/project/${id}`, { name, origins }, apiKey);
+      } catch {
+        /* origins update best-effort */
+      }
+    }
+    return id;
+  }
+  const created = await api("POST", "/v1/project", { name }, apiKey);
+  const id = projectIdOf(created);
+  console.log(`created project ${name} → ${id}`);
+  if (id && origins?.length) {
+    try {
+      await api("PUT", `/v1/project/${id}`, { name, origins }, apiKey);
+    } catch {
+      /* origins update best-effort */
+    }
+  }
+  return id;
+}
+
+async function ensureFunnel(apiKey, pid, name, steps) {
+  const list = await api("GET", `/v1/project/funnels/${pid}`, undefined, apiKey);
+  const rows = Array.isArray(list) ? list : list?.results ?? list?.data ?? [];
+  const existing = rows.find((f) => f?.name === name);
+  if (existing) {
+    console.log(`reuse funnel "${name}" on ${pid}`);
+    return existing.id ?? existing.funnelId;
+  }
+  const created = await api(
+    "POST",
+    "/v1/project/funnel",
+    { name, pid, steps },
+    apiKey,
+  );
+  console.log(`created funnel "${name}" on ${pid}`);
+  return created?.id ?? created?.funnelId;
+}
+
+async function main() {
+  const apiKey = loadApiKey();
+  const ids = {};
+  for (const p of PROJECTS) {
+    const id = await ensureProject(apiKey, p.name, p.origins);
+    if (!id) throw new Error(`No project id returned for ${p.name}`);
+    ids[p.name] = id;
+    writeEnvPid(p.envPath, id);
+    console.log(`wrote ${p.envPath}`);
+  }
+
+  await ensureFunnel(
+    apiKey,
+    ids["regenfass-installer"],
+    "Flash and configure",
+    INSTALLER_FUNNEL_STEPS,
+  );
+  await ensureFunnel(apiKey, ids["regenfass-marketing"], "Path to documentation", [
+    "/",
+    "navigate_to_docs",
+  ]);
+  await ensureFunnel(apiKey, ids["regenfass-marketing"], "Path to installer", [
+    "/",
+    "navigate_to_installer",
+  ]);
+
+  console.log(JSON.stringify({ projects: ids }, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/scripts/provision-swetrix.mjs
+++ b/scripts/provision-swetrix.mjs
@@ -1,31 +1,43 @@
 #!/usr/bin/env node
 /**
- * Provision Swetrix projects and funnels via the Admin API
+ * Provision Swetrix funnels (and optionally projects) via the Admin API
  * (same endpoints as mcp-swetrix admin tools).
+ *
+ * Prefers existing IDs from root `.env`:
+ *   SWETRIX_PROJECT_ID_INSTALLER / _MARKETING / _DOCS / _BRAND
  *
  * Usage (from repo root):
  *   node scripts/provision-swetrix.mjs
  *
- * Requires SWETRIX_API_KEY in the environment or /workspace/.env / .env.
+ * Requires SWETRIX_API_KEY for Admin API calls. Always runs
+ * scripts/sync-swetrix-env.mjs afterwards when IDs are present.
  */
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const BASE = process.env.SWETRIX_BASE_URL || "https://api.swetrix.com";
 
-function loadApiKey() {
-  if (process.env.SWETRIX_API_KEY?.trim()) return process.env.SWETRIX_API_KEY.trim();
-  for (const rel of [".env", "web/.env"]) {
-    const p = resolve(ROOT, rel);
-    if (!existsSync(p)) continue;
-    const text = readFileSync(p, "utf8");
-    const m = text.match(/^SWETRIX_API_KEY=(.+)$/m);
-    if (m) return m[1].trim().replace(/^["']|["']$/g, "");
+function loadRootEnv() {
+  const env = { ...process.env };
+  const p = resolve(ROOT, ".env");
+  if (existsSync(p)) {
+    for (const line of readFileSync(p, "utf8").split(/\r?\n/)) {
+      const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!m) continue;
+      env[m[1]] = m[2].trim().replace(/^["']|["']$/g, "");
+    }
   }
-  throw new Error("SWETRIX_API_KEY not found in env or .env");
+  return env;
+}
+
+function loadApiKey(env) {
+  const key = env.SWETRIX_API_KEY?.trim();
+  if (!key) throw new Error("SWETRIX_API_KEY not found in env or .env");
+  return key;
 }
 
 async function api(method, path, body, apiKey) {
@@ -56,23 +68,23 @@ async function api(method, path, body, apiKey) {
 const PROJECTS = [
   {
     name: "regenfass-installer",
+    envKey: "SWETRIX_PROJECT_ID_INSTALLER",
     origins: ["install.regenfass.eu"],
-    envPath: "web/installer/.env",
   },
   {
     name: "regenfass-marketing",
+    envKey: "SWETRIX_PROJECT_ID_MARKETING",
     origins: ["regenfass.eu"],
-    envPath: "web/marketing/.env",
   },
   {
     name: "regenfass-docs",
+    envKey: "SWETRIX_PROJECT_ID_DOCS",
     origins: ["docs.regenfass.eu"],
-    envPath: "web/docs/.env",
   },
   {
     name: "regenfass-brand",
+    envKey: "SWETRIX_PROJECT_ID_BRAND",
     origins: ["brand.regenfass.eu"],
-    envPath: "web/brand-showcase/.env",
   },
 ];
 
@@ -88,42 +100,36 @@ const INSTALLER_FUNNEL_STEPS = [
   "installer_state_Finish_ShowingNextSteps",
 ];
 
-function writeEnvPid(relPath, pid) {
-  const abs = resolve(ROOT, relPath);
-  const line = `VITE_SWETRIX_PROJECT_ID=${pid}\n`;
-  if (existsSync(abs)) {
-    const prev = readFileSync(abs, "utf8");
-    if (/^VITE_SWETRIX_PROJECT_ID=/m.test(prev)) {
-      writeFileSync(
-        abs,
-        prev.replace(/^VITE_SWETRIX_PROJECT_ID=.*$/m, `VITE_SWETRIX_PROJECT_ID=${pid}`),
-      );
-      return;
+function upsertRootEnv(keys) {
+  const abs = resolve(ROOT, ".env");
+  let text = existsSync(abs) ? readFileSync(abs, "utf8") : "";
+  for (const [k, v] of Object.entries(keys)) {
+    if (!v) continue;
+    const line = `${k}=${v}`;
+    if (new RegExp(`^${k}=`, "m").test(text)) {
+      text = text.replace(new RegExp(`^${k}=.*$`, "m"), line);
+    } else {
+      text = text.endsWith("\n") || text === "" ? `${text}${line}\n` : `${text}\n${line}\n`;
     }
-    writeFileSync(abs, prev.endsWith("\n") ? `${prev}${line}` : `${prev}\n${line}`);
-    return;
   }
-  writeFileSync(abs, line);
+  writeFileSync(abs, text);
 }
 
 function projectIdOf(row) {
   return row?.id ?? row?.pid ?? row?.projectId;
 }
 
-async function ensureProject(apiKey, name, origins) {
+async function ensureProject(apiKey, name, origins, existingId) {
+  if (existingId) {
+    console.log(`use existing project ${name} → ${existingId}`);
+    return existingId;
+  }
   const list = await api("GET", "/v1/project", undefined, apiKey);
   const rows = Array.isArray(list) ? list : list?.results ?? list?.data ?? [];
   const existing = rows.find((p) => p?.name === name);
   if (existing) {
     const id = projectIdOf(existing);
     console.log(`reuse project ${name} → ${id}`);
-    if (origins?.length) {
-      try {
-        await api("PUT", `/v1/project/${id}`, { name, origins }, apiKey);
-      } catch {
-        /* origins update best-effort */
-      }
-    }
     return id;
   }
   const created = await api("POST", "/v1/project", { name }, apiKey);
@@ -158,30 +164,61 @@ async function ensureFunnel(apiKey, pid, name, steps) {
 }
 
 async function main() {
-  const apiKey = loadApiKey();
+  const env = loadRootEnv();
   const ids = {};
-  for (const p of PROJECTS) {
-    const id = await ensureProject(apiKey, p.name, p.origins);
-    if (!id) throw new Error(`No project id returned for ${p.name}`);
-    ids[p.name] = id;
-    writeEnvPid(p.envPath, id);
-    console.log(`wrote ${p.envPath}`);
+  const hasAllIds = PROJECTS.every((p) => env[p.envKey]?.trim());
+
+  if (hasAllIds) {
+    for (const p of PROJECTS) {
+      ids[p.name] = env[p.envKey].trim();
+      console.log(`from .env ${p.envKey}=${ids[p.name]}`);
+    }
+  } else {
+    const apiKey = loadApiKey(env);
+    for (const p of PROJECTS) {
+      const id = await ensureProject(apiKey, p.name, p.origins, env[p.envKey]?.trim());
+      if (!id) throw new Error(`No project id for ${p.name}`);
+      ids[p.name] = id;
+    }
+    upsertRootEnv({
+      SWETRIX_PROJECT_ID_INSTALLER: ids["regenfass-installer"],
+      SWETRIX_PROJECT_ID_MARKETING: ids["regenfass-marketing"],
+      SWETRIX_PROJECT_ID_DOCS: ids["regenfass-docs"],
+      SWETRIX_PROJECT_ID_BRAND: ids["regenfass-brand"],
+    });
   }
 
-  await ensureFunnel(
-    apiKey,
-    ids["regenfass-installer"],
-    "Flash and configure",
-    INSTALLER_FUNNEL_STEPS,
-  );
-  await ensureFunnel(apiKey, ids["regenfass-marketing"], "Path to documentation", [
-    "/",
-    "navigate_to_docs",
-  ]);
-  await ensureFunnel(apiKey, ids["regenfass-marketing"], "Path to installer", [
-    "/",
-    "navigate_to_installer",
-  ]);
+  try {
+    const apiKey = loadApiKey(env);
+    await ensureFunnel(
+      apiKey,
+      ids["regenfass-installer"],
+      "Flash and configure",
+      INSTALLER_FUNNEL_STEPS,
+    );
+    await ensureFunnel(apiKey, ids["regenfass-marketing"], "Path to documentation", [
+      "/",
+      "navigate_to_docs",
+    ]);
+    await ensureFunnel(apiKey, ids["regenfass-marketing"], "Path to installer", [
+      "/",
+      "navigate_to_installer",
+    ]);
+  } catch (err) {
+    console.warn(`Funnel/Admin API step skipped: ${err.message || err}`);
+    console.warn(
+      "Create funnels in the Swetrix dashboard (see docs/Local-Development.md), or fix SWETRIX_API_KEY.",
+    );
+  }
+
+  const sync = spawnSync(process.execPath, [resolve(ROOT, "scripts/sync-swetrix-env.mjs")], {
+    cwd: ROOT,
+    stdio: "inherit",
+    env: { ...process.env, ...env, ...Object.fromEntries(
+      PROJECTS.map((p) => [p.envKey, ids[p.name]]),
+    )},
+  });
+  if (sync.status !== 0) process.exit(sync.status || 1);
 
   console.log(JSON.stringify({ projects: ids }, null, 2));
 }

--- a/scripts/provision-swetrix.mjs
+++ b/scripts/provision-swetrix.mjs
@@ -19,7 +19,6 @@ import { spawnSync } from "node:child_process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
-const BASE = process.env.SWETRIX_BASE_URL || "https://api.swetrix.com";
 
 function loadRootEnv() {
   const env = { ...process.env };
@@ -33,6 +32,12 @@ function loadRootEnv() {
   }
   return env;
 }
+
+const rootEnvEarly = loadRootEnv();
+const BASE =
+  rootEnvEarly.SWETRIX_BASE_URL?.trim() ||
+  process.env.SWETRIX_BASE_URL?.trim() ||
+  "https://api.swetrix.com";
 
 function loadApiKey(env) {
   const key = env.SWETRIX_API_KEY?.trim();

--- a/scripts/swetrix-funnels.json
+++ b/scripts/swetrix-funnels.json
@@ -1,0 +1,47 @@
+{
+  "funnels": [
+    {
+      "projectEnv": "SWETRIX_PROJECT_ID_INSTALLER",
+      "projectName": "regenfass.eu.installer",
+      "name": "Flash and configure",
+      "steps": [
+        { "type": "event", "value": "installer_state_Start_WaitingForUser" },
+        { "type": "event", "value": "installer_state_Connect_Connecting" },
+        { "type": "event", "value": "installer_state_Connect_ReadingVersion" },
+        {
+          "type": "event",
+          "value": "installer_state_Install_WaitingForInstallationMethodChoice"
+        },
+        { "type": "event", "value": "installer_state_Install_Installing" },
+        {
+          "type": "event",
+          "value": "installer_state_Install_MigratingConfiguration"
+        },
+        { "type": "event", "value": "installer_state_Config_Editing" },
+        {
+          "type": "event",
+          "value": "installer_state_Config_WritingConfiguration"
+        },
+        { "type": "event", "value": "installer_state_Finish_ShowingNextSteps" }
+      ]
+    },
+    {
+      "projectEnv": "SWETRIX_PROJECT_ID_MARKETING",
+      "projectName": "regenfass.eu",
+      "name": "Path to documentation",
+      "steps": [
+        { "type": "page", "value": "/" },
+        { "type": "event", "value": "navigate_to_docs" }
+      ]
+    },
+    {
+      "projectEnv": "SWETRIX_PROJECT_ID_MARKETING",
+      "projectName": "regenfass.eu",
+      "name": "Path to installer",
+      "steps": [
+        { "type": "page", "value": "/" },
+        { "type": "event", "value": "navigate_to_installer" }
+      ]
+    }
+  ]
+}

--- a/scripts/sync-swetrix-env.mjs
+++ b/scripts/sync-swetrix-env.mjs
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 /**
- * Sync root `.env` Swetrix project IDs into each Vite app's `.env`
- * as `VITE_SWETRIX_PROJECT_ID` (required for client-side Vite exposure).
+ * Sync root `.env` Swetrix settings into each Vite app's `.env`.
  *
  * Expected root vars (no VITE_ prefix):
- *   SWETRIX_PROJECT_ID_INSTALLER
- *   SWETRIX_PROJECT_ID_MARKETING
- *   SWETRIX_PROJECT_ID_DOCS
- *   SWETRIX_PROJECT_ID_BRAND
+ *   SWETRIX_PROJECT_ID_INSTALLER / _MARKETING / _DOCS / _BRAND
+ *   SWETRIX_API_URL (optional) — Events API log endpoint for the JS SDK
+ *     Cloud: omit (defaults to https://api.swetrix.com/log)
+ *     Self-hosted CE: https://your-host/backend/log
  *
  * Usage (from repo root):
  *   node scripts/sync-swetrix-env.mjs
@@ -40,25 +39,28 @@ function loadRootEnv() {
   return env;
 }
 
-function writeAppEnv(relDir, pid) {
-  const abs = resolve(ROOT, relDir, ".env");
-  const line = `VITE_SWETRIX_PROJECT_ID=${pid}\n`;
-  if (existsSync(abs)) {
-    const prev = readFileSync(abs, "utf8");
-    if (/^VITE_SWETRIX_PROJECT_ID=/m.test(prev)) {
-      writeFileSync(
-        abs,
-        prev.replace(/^VITE_SWETRIX_PROJECT_ID=.*$/m, `VITE_SWETRIX_PROJECT_ID=${pid}`),
-      );
-      return;
+function upsertEnvFile(abs, entries) {
+  let text = existsSync(abs) ? readFileSync(abs, "utf8") : "";
+  for (const [k, v] of Object.entries(entries)) {
+    if (v === undefined || v === null || v === "") {
+      // Drop empty optional keys
+      if (new RegExp(`^${k}=`, "m").test(text)) {
+        text = text.replace(new RegExp(`^${k}=.*\\n?`, "m"), "");
+      }
+      continue;
     }
-    writeFileSync(abs, prev.endsWith("\n") ? `${prev}${line}` : `${prev}\n${line}`);
-    return;
+    const line = `${k}=${v}`;
+    if (new RegExp(`^${k}=`, "m").test(text)) {
+      text = text.replace(new RegExp(`^${k}=.*$`, "m"), line);
+    } else {
+      text = text.endsWith("\n") || text === "" ? `${text}${line}\n` : `${text}\n${line}\n`;
+    }
   }
-  writeFileSync(abs, line);
+  writeFileSync(abs, text.endsWith("\n") || text === "" ? text : `${text}\n`);
 }
 
 const env = loadRootEnv();
+const apiURL = env.SWETRIX_API_URL?.trim() || env.VITE_SWETRIX_API_URL?.trim() || "";
 let wrote = 0;
 for (const app of APPS) {
   const pid = env[app.envKey]?.trim();
@@ -66,8 +68,12 @@ for (const app of APPS) {
     console.warn(`skip ${app.dir}: ${app.envKey} not set`);
     continue;
   }
-  writeAppEnv(app.dir, pid);
-  console.log(`${app.dir}/.env ← ${pid}`);
+  const abs = resolve(ROOT, app.dir, ".env");
+  upsertEnvFile(abs, {
+    VITE_SWETRIX_PROJECT_ID: pid,
+    VITE_SWETRIX_API_URL: apiURL,
+  });
+  console.log(`${app.dir}/.env ← pid=${pid}${apiURL ? ` api=${apiURL}` : ""}`);
   wrote += 1;
 }
 if (wrote === 0) {

--- a/scripts/sync-swetrix-env.mjs
+++ b/scripts/sync-swetrix-env.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Sync root `.env` Swetrix project IDs into each Vite app's `.env`
+ * as `VITE_SWETRIX_PROJECT_ID` (required for client-side Vite exposure).
+ *
+ * Expected root vars (no VITE_ prefix):
+ *   SWETRIX_PROJECT_ID_INSTALLER
+ *   SWETRIX_PROJECT_ID_MARKETING
+ *   SWETRIX_PROJECT_ID_DOCS
+ *   SWETRIX_PROJECT_ID_BRAND
+ *
+ * Usage (from repo root):
+ *   node scripts/sync-swetrix-env.mjs
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const APPS = [
+  { envKey: "SWETRIX_PROJECT_ID_INSTALLER", dir: "web/installer" },
+  { envKey: "SWETRIX_PROJECT_ID_MARKETING", dir: "web/marketing" },
+  { envKey: "SWETRIX_PROJECT_ID_DOCS", dir: "web/docs" },
+  { envKey: "SWETRIX_PROJECT_ID_BRAND", dir: "web/brand-showcase" },
+];
+
+function loadRootEnv() {
+  const env = { ...process.env };
+  for (const rel of [".env"]) {
+    const p = resolve(ROOT, rel);
+    if (!existsSync(p)) continue;
+    for (const line of readFileSync(p, "utf8").split(/\r?\n/)) {
+      const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!m) continue;
+      env[m[1]] = m[2].trim().replace(/^["']|["']$/g, "");
+    }
+  }
+  return env;
+}
+
+function writeAppEnv(relDir, pid) {
+  const abs = resolve(ROOT, relDir, ".env");
+  const line = `VITE_SWETRIX_PROJECT_ID=${pid}\n`;
+  if (existsSync(abs)) {
+    const prev = readFileSync(abs, "utf8");
+    if (/^VITE_SWETRIX_PROJECT_ID=/m.test(prev)) {
+      writeFileSync(
+        abs,
+        prev.replace(/^VITE_SWETRIX_PROJECT_ID=.*$/m, `VITE_SWETRIX_PROJECT_ID=${pid}`),
+      );
+      return;
+    }
+    writeFileSync(abs, prev.endsWith("\n") ? `${prev}${line}` : `${prev}\n${line}`);
+    return;
+  }
+  writeFileSync(abs, line);
+}
+
+const env = loadRootEnv();
+let wrote = 0;
+for (const app of APPS) {
+  const pid = env[app.envKey]?.trim();
+  if (!pid) {
+    console.warn(`skip ${app.dir}: ${app.envKey} not set`);
+    continue;
+  }
+  writeAppEnv(app.dir, pid);
+  console.log(`${app.dir}/.env ← ${pid}`);
+  wrote += 1;
+}
+if (wrote === 0) {
+  console.error("No SWETRIX_PROJECT_ID_* values found in root .env or environment.");
+  process.exit(1);
+}

--- a/web/brand-showcase/.env.example
+++ b/web/brand-showcase/.env.example
@@ -1,3 +1,4 @@
-# Swetrix project ID for this web app (from the Swetrix dashboard).
-# Leave empty to disable analytics locally.
+# Filled by `node scripts/sync-swetrix-env.mjs` from the repo root `.env`
+# (SWETRIX_PROJECT_ID_BRAND → VITE_SWETRIX_PROJECT_ID).
+# Vite only exposes VITE_* vars to the browser.
 VITE_SWETRIX_PROJECT_ID=

--- a/web/brand-showcase/.env.example
+++ b/web/brand-showcase/.env.example
@@ -1,0 +1,3 @@
+# Swetrix project ID for this web app (from the Swetrix dashboard).
+# Leave empty to disable analytics locally.
+VITE_SWETRIX_PROJECT_ID=

--- a/web/brand-showcase/src/index.tsx
+++ b/web/brand-showcase/src/index.tsx
@@ -1,8 +1,11 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
+import { initAnalytics } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
+
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID);
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");

--- a/web/brand-showcase/src/index.tsx
+++ b/web/brand-showcase/src/index.tsx
@@ -5,7 +5,9 @@ import { initAnalytics } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
 
-initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID);
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
+  apiURL: import.meta.env.VITE_SWETRIX_API_URL,
+});
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");

--- a/web/brand-showcase/src/vite-env.d.ts
+++ b/web/brand-showcase/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_SWETRIX_PROJECT_ID?: string;
+  readonly VITE_SWETRIX_API_URL?: string;
 }
 
 interface ImportMeta {

--- a/web/brand-showcase/src/vite-env.d.ts
+++ b/web/brand-showcase/src/vite-env.d.ts
@@ -1,2 +1,10 @@
 /* eslint-disable */
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SWETRIX_PROJECT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/web/brand/package.json
+++ b/web/brand/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "lucide-solid": "^0.543.0",
     "solid-icons": "^1.1.0",
+    "swetrix": "^4.4.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/web/brand/src/components/atoms/ButtonModeToggle.tsx
+++ b/web/brand/src/components/atoms/ButtonModeToggle.tsx
@@ -2,6 +2,7 @@ import { Button } from "./Button.tsx";
 import Moon from "lucide-solid/icons/moon";
 import Sun from "lucide-solid/icons/sun";
 import { useColorMode } from "@kobalte/core/color-mode";
+import { trackEvent } from "../../libs/analytics.ts";
 
 export function ButtonModeToggle() {
 	const { colorMode, setColorMode } = useColorMode();
@@ -16,6 +17,7 @@ export function ButtonModeToggle() {
 		try {
 			localStorage.setItem("theme", isDark ? "dark" : "light");
 		} catch {}
+		trackEvent("theme_toggled", { theme: next });
 	};
 
 	return (

--- a/web/brand/src/components/organisms/Header.tsx
+++ b/web/brand/src/components/organisms/Header.tsx
@@ -9,6 +9,8 @@ export type HeaderNavItem = {
   label: string;
   /** Use Solid router `<A>` for in-app paths; external http(s) always use `<a>`/`Link`. */
   external?: boolean;
+  /** Optional click handler (e.g. analytics before navigate). */
+  onClick?: JSX.EventHandlerUnion<HTMLAnchorElement, MouseEvent>;
 };
 
 export type HeaderProps = {
@@ -60,12 +62,13 @@ const Header: Component<HeaderProps> = (rawProps) => {
                           "p-2 hover:text-foreground hover:underline",
                           "transition-colors",
                         )}
+                        onClick={item.onClick}
                       >
                         {item.label}
                       </A>
                     }
                   >
-                    <Link href={item.href} class="p-2">
+                    <Link href={item.href} class="p-2" onClick={item.onClick}>
                       {item.label}
                     </Link>
                   </Show>

--- a/web/brand/src/index.ts
+++ b/web/brand/src/index.ts
@@ -92,6 +92,16 @@ export { TextInput } from "./components/forms/TextInput.tsx";
 // Utils
 export { cn } from "./libs/cn.ts";
 export {
+  initAnalytics,
+  isAnalyticsInitialized,
+  trackEvent,
+  resetAnalyticsForTests,
+} from "./libs/analytics.ts";
+export type {
+  AnalyticsMeta,
+  InitAnalyticsOptions,
+} from "./libs/analytics.ts";
+export {
   soundEnabled,
   isSoundEnabled,
   setSoundEnabled,

--- a/web/brand/src/libs/analytics.ts
+++ b/web/brand/src/libs/analytics.ts
@@ -10,9 +10,21 @@ export type InitAnalyticsOptions = {
 	devMode?: boolean;
 	/** Force-disable tracking even when a project ID is present. */
 	disabled?: boolean;
+	/**
+	 * Events API base URL including the `/log` path.
+	 * Cloud default: `https://api.swetrix.com/log`
+	 * Self-hosted CE example: `https://analytics.example.com/backend/log`
+	 */
+	apiURL?: string;
 };
 
 let initialized = false;
+
+function resolveApiURL(explicit?: string): string | undefined {
+	const fromOpt = explicit?.trim();
+	if (fromOpt) return fromOpt;
+	return undefined;
+}
 
 /**
  * Initialise Swetrix page views and error tracking for this app.
@@ -29,9 +41,11 @@ export function initAnalytics(
 	}
 	if (initialized) return;
 
+	const apiURL = resolveApiURL(options.apiURL);
 	init(pid, {
 		devMode: options.devMode === true,
 		disabled: false,
+		...(apiURL ? { apiURL } : {}),
 	});
 	void trackViews();
 	trackErrors();

--- a/web/brand/src/libs/analytics.ts
+++ b/web/brand/src/libs/analytics.ts
@@ -1,0 +1,61 @@
+import { init, track, trackErrors, trackViews } from "swetrix";
+
+export type AnalyticsMeta = Record<
+	string,
+	string | number | boolean | null | undefined
+>;
+
+export type InitAnalyticsOptions = {
+	/** When true, send events from localhost. Default: false. */
+	devMode?: boolean;
+	/** Force-disable tracking even when a project ID is present. */
+	disabled?: boolean;
+};
+
+let initialized = false;
+
+/**
+ * Initialise Swetrix page views and error tracking for this app.
+ * No-ops when `projectId` is missing/blank (safe for local/dev without credentials).
+ */
+export function initAnalytics(
+	projectId: string | undefined,
+	options: InitAnalyticsOptions = {},
+): void {
+	const pid = projectId?.trim();
+	if (!pid || options.disabled === true) {
+		initialized = false;
+		return;
+	}
+	if (initialized) return;
+
+	init(pid, {
+		devMode: options.devMode === true,
+		disabled: false,
+	});
+	void trackViews();
+	trackErrors();
+	initialized = true;
+}
+
+/** Whether `initAnalytics` succeeded with a project ID in this session. */
+export function isAnalyticsInitialized(): boolean {
+	return initialized;
+}
+
+/**
+ * Track a custom Swetrix event. Safe no-op when analytics was not initialised.
+ */
+export function trackEvent(ev: string, meta?: AnalyticsMeta): void {
+	if (!initialized || !ev) return;
+	const payload: { ev: string; meta?: AnalyticsMeta } = { ev };
+	if (meta && Object.keys(meta).length > 0) {
+		payload.meta = meta;
+	}
+	track(payload);
+}
+
+/** Reset init flag (tests only). */
+export function resetAnalyticsForTests(): void {
+	initialized = false;
+}

--- a/web/docs/.env.example
+++ b/web/docs/.env.example
@@ -1,3 +1,4 @@
-# Swetrix project ID for this web app (from the Swetrix dashboard).
-# Leave empty to disable analytics locally.
+# Filled by `node scripts/sync-swetrix-env.mjs` from the repo root `.env`
+# (SWETRIX_PROJECT_ID_DOCS → VITE_SWETRIX_PROJECT_ID).
+# Vite only exposes VITE_* vars to the browser.
 VITE_SWETRIX_PROJECT_ID=

--- a/web/docs/.env.example
+++ b/web/docs/.env.example
@@ -1,0 +1,3 @@
+# Swetrix project ID for this web app (from the Swetrix dashboard).
+# Leave empty to disable analytics locally.
+VITE_SWETRIX_PROJECT_ID=

--- a/web/docs/src/index.tsx
+++ b/web/docs/src/index.tsx
@@ -1,8 +1,11 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
+import { initAnalytics } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
+
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID);
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");

--- a/web/docs/src/index.tsx
+++ b/web/docs/src/index.tsx
@@ -5,7 +5,9 @@ import { initAnalytics } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
 
-initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID);
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
+  apiURL: import.meta.env.VITE_SWETRIX_API_URL,
+});
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");

--- a/web/docs/src/vite-env.d.ts
+++ b/web/docs/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_SWETRIX_PROJECT_ID?: string;
+  readonly VITE_SWETRIX_API_URL?: string;
 }
 
 interface ImportMeta {

--- a/web/docs/src/vite-env.d.ts
+++ b/web/docs/src/vite-env.d.ts
@@ -1,6 +1,14 @@
 /* eslint-disable */
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_SWETRIX_PROJECT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module "*.md?raw" {
   const content: string;
   export default content;

--- a/web/installer/.env.example
+++ b/web/installer/.env.example
@@ -1,3 +1,4 @@
-# Swetrix project ID for this web app (from the Swetrix dashboard).
-# Leave empty to disable analytics locally.
+# Filled by `node scripts/sync-swetrix-env.mjs` from the repo root `.env`
+# (SWETRIX_PROJECT_ID_INSTALLER → VITE_SWETRIX_PROJECT_ID).
+# Vite only exposes VITE_* vars to the browser.
 VITE_SWETRIX_PROJECT_ID=

--- a/web/installer/.env.example
+++ b/web/installer/.env.example
@@ -1,0 +1,3 @@
+# Swetrix project ID for this web app (from the Swetrix dashboard).
+# Leave empty to disable analytics locally.
+VITE_SWETRIX_PROJECT_ID=

--- a/web/installer/docs/components/organisms/header.md
+++ b/web/installer/docs/components/organisms/header.md
@@ -1,25 +1,45 @@
 # Header
 
-Main navigation header used at the top of the installer interface.
+Main navigation header used at the top of installer and other Regenfass web UIs (from `@regenfass/brand`).
 
 ```tsx
-import Header from '@/components/organisms/Header';
+import { Header, type HeaderNavItem } from "@regenfass/brand";
 
-<Header />
+const navItems: HeaderNavItem[] = [
+  { href: "/", label: "Home" },
+  {
+    href: "https://docs.regenfass.eu/",
+    label: "Docs",
+    external: true,
+    onClick: () => {
+      /* optional analytics / side effects */
+    },
+  },
+];
+
+<Header title="Regenfass" navItems={navItems} />
 ```
 
 ## Props
 
-This component accepts no props - it's a static header with fixed navigation links and branding.
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | `"Regenfass"` | Optional brand title shown in the header. |
+| `navItems` | `HeaderNavItem[]` | Docs / installer / GitHub / Matrix defaults | Navigation items. |
+| `trailing` | `JSX.Element` | — | Extra controls rendered next to the color-mode toggle. |
+
+### `HeaderNavItem`
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| -    | -    | -       | No props available |
+| `href` | `string` | required | Link target. |
+| `label` | `string` | required | Visible label. |
+| `external` | `boolean` | inferred from `http(s)` | Force external `<a>`/`Link` instead of router `<A>`. |
+| `onClick` | `(e) => void` | — | Optional click handler (for example analytics before navigate). |
 
 ## Design notes
 
 - Features the Regenfass brand name with gradient text styling
-- Includes fixed navigation links to documentation, GitHub, and Matrix
 - Navigation is hidden on mobile devices (`hidden md:block`)
 - Integrates the ButtonModeToggle component for dark/light theme switching
 - Uses responsive layout with max-width container and proper spacing

--- a/web/installer/src/components/molecules/steps/Steps.tsx
+++ b/web/installer/src/components/molecules/steps/Steps.tsx
@@ -1,7 +1,8 @@
 import { setupStateMachine } from "@/libs/install/state.ts";
+import { trackEvent } from "@regenfass/brand";
 import { createBrowserInspector } from "@statelyai/inspect";
 import { fromActorRef, useActorRef } from "@xstate/solid";
-import { Match, Switch } from "solid-js";
+import { createEffect, Match, Switch } from "solid-js";
 import StepStartCheckingWebSerialSupport from "./StepStartCheckingWebSerialSupport.tsx";
 import StepStartFetchUpstreamVersions from "./StepStartFetchUpstreamVersions.tsx";
 import StepStartWaitingForUser from "./StepStartWaitingForUser.tsx";
@@ -19,6 +20,15 @@ const inspect = import.meta.env.DEV
 	? createBrowserInspector().inspect
 	: undefined;
 
+function stateNameFromValue(value: unknown): string | undefined {
+	if (typeof value === "string") return value;
+	if (value && typeof value === "object") {
+		const keys = Object.keys(value as Record<string, unknown>);
+		return keys[0];
+	}
+	return undefined;
+}
+
 export default function Steps() {
 	// useMachine’s first tuple value is a one-shot snapshot in @xstate/solid 2.0.0 (it calls
 	// `fromActorRef(actorRef)()`), so Switch/Match would never see transitions. Use the actor
@@ -28,6 +38,14 @@ export default function Steps() {
 	});
 	const snapshot = fromActorRef(actorRef);
 	const send = actorRef.send;
+
+	let lastTrackedState: string | undefined;
+	createEffect(() => {
+		const name = stateNameFromValue(snapshot().value);
+		if (!name || name === lastTrackedState) return;
+		lastTrackedState = name;
+		trackEvent(`installer_state_${name}`);
+	});
 
 	return (
 		<div class="site-container py-6 space-y-6">

--- a/web/installer/src/index.tsx
+++ b/web/installer/src/index.tsx
@@ -1,8 +1,11 @@
 /* @refresh reload */
 import { render } from 'solid-js/web'
+import { initAnalytics } from '@regenfass/brand'
 
 import './index.css'
 import App from './App'
+
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID)
 
 // Initialize theme from localStorage or system preference
 (() => {

--- a/web/installer/src/index.tsx
+++ b/web/installer/src/index.tsx
@@ -7,7 +7,7 @@ import App from './App'
 
 initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
   apiURL: import.meta.env.VITE_SWETRIX_API_URL,
-})
+});
 
 // Initialize theme from localStorage or system preference
 (() => {

--- a/web/installer/src/index.tsx
+++ b/web/installer/src/index.tsx
@@ -5,7 +5,9 @@ import { initAnalytics } from '@regenfass/brand'
 import './index.css'
 import App from './App'
 
-initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID)
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
+  apiURL: import.meta.env.VITE_SWETRIX_API_URL,
+})
 
 // Initialize theme from localStorage or system preference
 (() => {

--- a/web/installer/src/vite-env.d.ts
+++ b/web/installer/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SWETRIX_PROJECT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/web/installer/src/vite-env.d.ts
+++ b/web/installer/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_SWETRIX_PROJECT_ID?: string;
+  readonly VITE_SWETRIX_API_URL?: string;
 }
 
 interface ImportMeta {

--- a/web/installer/tests/components/atoms/ButtonModeToggle.test.tsx
+++ b/web/installer/tests/components/atoms/ButtonModeToggle.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@solidjs/testing-library";
 import { ButtonModeToggle } from "@regenfass/brand";
 
+vi.mock("swetrix", () => ({
+  init: vi.fn(),
+  track: vi.fn(),
+  trackViews: vi.fn(async () => ({ stop: vi.fn() })),
+  trackErrors: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
 // Mock useColorMode hook
 // Note: We need to import createSignal inside the mock factory due to hoisting
 vi.mock("@kobalte/core/color-mode", async () => {

--- a/web/installer/tests/components/molecules/steps/Steps.test.tsx
+++ b/web/installer/tests/components/molecules/steps/Steps.test.tsx
@@ -5,6 +5,7 @@ import Steps from "@/components/molecules/steps/Steps.tsx";
 // Mock XState Solid — Steps uses useActorRef + fromActorRef for reactive snapshots
 vi.mock("@xstate/solid", () => {
   const mockSnapshot = {
+    value: "Start_WaitingForUser",
     matches: (value: string) => value === "Start_WaitingForUser",
     toJSON: () => ({ value: "Start_WaitingForUser" }),
   };

--- a/web/marketing/.env.example
+++ b/web/marketing/.env.example
@@ -1,3 +1,4 @@
-# Swetrix project ID for this web app (from the Swetrix dashboard).
-# Leave empty to disable analytics locally.
+# Filled by `node scripts/sync-swetrix-env.mjs` from the repo root `.env`
+# (SWETRIX_PROJECT_ID_MARKETING → VITE_SWETRIX_PROJECT_ID).
+# Vite only exposes VITE_* vars to the browser.
 VITE_SWETRIX_PROJECT_ID=

--- a/web/marketing/.env.example
+++ b/web/marketing/.env.example
@@ -1,0 +1,3 @@
+# Swetrix project ID for this web app (from the Swetrix dashboard).
+# Leave empty to disable analytics locally.
+VITE_SWETRIX_PROJECT_ID=

--- a/web/marketing/src/App.tsx
+++ b/web/marketing/src/App.tsx
@@ -14,17 +14,36 @@ import {
   Headline,
   Link,
   Newsletter,
+  trackEvent,
+  type HeaderNavItem,
 } from "@regenfass/brand";
 import ChangelogSection from "./ChangelogSection";
 
-const NAV = [
+const DOCS_URL = "https://docs.regenfass.eu/";
+const INSTALLER_URL = "https://install.regenfass.eu";
+
+function trackNavigateToDocs() {
+  trackEvent("navigate_to_docs");
+}
+
+function trackNavigateToInstaller() {
+  trackEvent("navigate_to_installer");
+}
+
+const NAV: HeaderNavItem[] = [
   { href: "/", label: "Home" },
   { href: "/#changelog", label: "Changelog" },
-  { href: "https://docs.regenfass.eu/", label: "Docs", external: true },
   {
-    href: "https://install.regenfass.eu",
+    href: DOCS_URL,
+    label: "Docs",
+    external: true,
+    onClick: trackNavigateToDocs,
+  },
+  {
+    href: INSTALLER_URL,
     label: "Installer",
     external: true,
+    onClick: trackNavigateToInstaller,
   },
   { href: "https://brand.regenfass.eu", label: "Brand", external: true },
   {
@@ -118,12 +137,12 @@ function Home() {
             and The Things Network—built by TTN Leipzig.
           </p>
           <div class="mt-8 flex flex-wrap items-center gap-3">
-            <a href="https://install.regenfass.eu">
+            <a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
               <ButtonPrimary class="px-5 py-2.5 text-base">
                 Get started
               </ButtonPrimary>
             </a>
-            <a href="https://docs.regenfass.eu/">
+            <a href={DOCS_URL} onClick={trackNavigateToDocs}>
               <ButtonSecondary class="px-5 py-2.5 text-base">
                 Read docs
               </ButtonSecondary>
@@ -199,7 +218,10 @@ function Home() {
         </div>
         <p class="text-sm text-muted-foreground">
           Full bill of materials and wiring diagrams live in the{" "}
-          <Link href="https://docs.regenfass.eu/">documentation</Link>.
+          <Link href={DOCS_URL} onClick={trackNavigateToDocs}>
+            documentation
+          </Link>
+          .
         </p>
       </section>
 
@@ -214,7 +236,7 @@ function Home() {
               project’s license on GitHub.
             </p>
             <div class="flex flex-wrap gap-3 pt-2">
-              <a href="https://install.regenfass.eu">
+              <a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
                 <ButtonPrimary>Open installer</ButtonPrimary>
               </a>
               <Link href="https://github.com/ttnleipzig/regenfass">
@@ -266,10 +288,10 @@ function Home() {
             reading your rain barrel from anywhere with coverage.
           </p>
           <div class="flex flex-wrap justify-center gap-3">
-            <a href="https://install.regenfass.eu">
+            <a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
               <ButtonPrimary class="px-5 py-2.5">Get started</ButtonPrimary>
             </a>
-            <a href="https://docs.regenfass.eu/">
+            <a href={DOCS_URL} onClick={trackNavigateToDocs}>
               <ButtonSecondary class="px-5 py-2.5">Read the docs</ButtonSecondary>
             </a>
           </div>

--- a/web/marketing/src/index.tsx
+++ b/web/marketing/src/index.tsx
@@ -1,8 +1,11 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
+import { initAnalytics } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
+
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID);
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");

--- a/web/marketing/src/index.tsx
+++ b/web/marketing/src/index.tsx
@@ -5,7 +5,9 @@ import { initAnalytics } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
 
-initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID);
+initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
+  apiURL: import.meta.env.VITE_SWETRIX_API_URL,
+});
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element #root not found");

--- a/web/marketing/src/vite-env.d.ts
+++ b/web/marketing/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_SWETRIX_PROJECT_ID?: string;
+  readonly VITE_SWETRIX_API_URL?: string;
 }
 
 interface ImportMeta {

--- a/web/marketing/src/vite-env.d.ts
+++ b/web/marketing/src/vite-env.d.ts
@@ -1,6 +1,9 @@
 /// <reference types="vite/client" />
 
-declare module "*.md?raw" {
-  const content: string;
-  export default content;
+interface ImportMetaEnv {
+  readonly VITE_SWETRIX_PROJECT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Swetrix analytics to all four Vite apps against the self-hosted CE instance at `https://analytics-api.kieks.me`.

### Wired
- Shared `initAnalytics` / `trackEvent` in `@regenfass/brand`
- Events: `theme_toggled`, `installer_state_*`, `navigate_to_docs` / `navigate_to_installer`
- Root env: `SWETRIX_PROJECT_ID_*` + `SWETRIX_API_URL=https://analytics-api.kieks.me/log`
- CI injects the same into each app as `VITE_*` before Vite build

### Projects & funnels (created on self-host)
| Project | ID | Origins / funnels |
|---------|-----|-------------------|
| regenfass.eu | `RChSgY2dPcoT` | origins `regenfass.eu`; funnels **Path to documentation**, **Path to installer** |
| regenfass.eu.installer | `hTTfsYdXCsxr` | origins `install.regenfass.eu`; funnel **Flash and configure** |
| regenfass.eu.docs | `Eh3EAS8IBws7` | origins `docs.regenfass.eu` |
| regenfass.eu.brand | `Q1CQtK84V5qQ` | origins `brand.regenfass.eu` |

### Follow-up secrets (GitHub `production`)
- `SWETRIX_PROJECT_ID_INSTALLER` / `_MARKETING` / `_DOCS` / `_BRAND`
- `SWETRIX_API_URL` = `https://analytics-api.kieks.me/log`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87da6571-f62f-4802-9026-c57cd178cf16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87da6571-f62f-4802-9026-c57cd178cf16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

