### PR TITLE
fix(ci): use GITHUB_TOKEN for Release Please PRs

### DIFF
--- a/.github/workflows/sketch-release.yml
+++ b/.github/workflows/sketch-release.yml
@@ -61,7 +61,10 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_ORGANISATION || github.token }}
+          # Use GITHUB_TOKEN — job already has contents:write + pull-requests:write.
+          # Do not prefer secrets.RELEASE_PLEASE_ORGANISATION: if that PAT is set but
+          # lacks push access, GitHub returns 404 on git/refs and no release PR opens.
+          token: ${{ github.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
       - name: Print the release URL if present

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -61,8 +61,23 @@ flowchart LR
 
 - `config-file: .release-please-config.json`
 - `manifest-file: .release-please-manifest.json`
+- `token: ${{ github.token }}` (job permissions: `contents: write`, `pull-requests: write`)
 
 Do not pass a conflicting `release-type` in the action inputs; the config file is authoritative.
+
+### Token notes
+
+The default `GITHUB_TOKEN` is enough to open/update the release PR and to upload
+firmware artifacts in the **same** workflow run after a release is created.
+
+An organisation PAT (for example a former `RELEASE_PLEASE_ORGANISATION` secret) is
+only useful if you need cascading workflows that the default token cannot trigger
+(for example a separate workflow on the release tag). If you reintroduce such a
+token, it must have push access to this repository (and Org SSO authorised when
+required). GitHub often returns **404** (not 403) when creating refs with a token
+that cannot write — Release Please then fails with “Error creating Pull Request:
+Not Found” and never opens a PR. Prefer removing a broken Org secret over leaving
+it set with a `|| github.token` fallback, because a set secret skips the fallback.
 
 ## Installer commit lint
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release Please was failing to open release PRs with `Error creating Pull Request: Not Found` (HTTP 404 on `POST …/git/refs`). The workflow preferred `secrets.RELEASE_PLEASE_ORGANISATION`, and that PAT lacked push access — so the `|| github.token` fallback never ran.

This change switches Release Please to `${{ github.token }}` (the release job already has `contents: write` and `pull-requests: write`) and documents token requirements in `docs/Release-Process.md`.

`version.txt` is unchanged: it remains the Release Please `version-file` and a Netlify deploy path filter; runtime still uses `version.h` / `APP_VERSION`.

## After merge (manual)

1. Confirm **Sketch - release** succeeds on `main` and opens/updates a release PR (`release-please--branches--main--components--regenfass`).
2. Optionally **delete or rotate** repo/org secret `RELEASE_PLEASE_ORGANISATION` so a broken PAT is not reused later.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a49154c-be40-4492-86b2-2ac63ae1c390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a49154c-be40-4492-86b2-2ac63ae1c390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

