### PR TITLE
feat(web): DE/EN i18n for marketing and installer

### DIFF
--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -129,6 +129,19 @@ node scripts/provision-swetrix.mjs
 - `Path to documentation`: page `/` → event `navigate_to_docs`
 - `Path to installer`: page `/` → event `navigate_to_installer`
 
+## Locales (marketing + installer)
+
+Marketing and the installer support **German** and **English**.
+
+| Concern        | Behavior                                                                                                                                                                                                 |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Detection      | Cookie override → browser languages (`de*` → `de`, else `en`) → fallback `en`                                                                                                                            |
+| Cookie         | Name `regenfass-locale`, values `de` \| `en`. On `*.regenfass.eu` the cookie uses `Domain=.regenfass.eu` so marketing and installer share the choice. On localhost / Netlify previews the cookie is host-only. |
+| Marketing URLs | SEO paths `/de` and `/en`. `/` redirects to the resolved locale (hash preserved, e.g. `#changelog`). Language switcher updates the cookie and navigates.                                                  |
+| Installer      | Locale is **not** in the URL (stays `/`). The header switcher only updates the cookie and re-renders copy.                                                                                               |
+
+Shared helpers live in `@regenfass/brand` (`LocaleProvider`, `resolveLocale`, `LanguageSwitcher`).
+
 ## SolidJS reminder
 
 Installer and brand UIs use **SolidJS only** — do not introduce React.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@corvu/otp-field':
         specifier: ^0.1.4
         version: 0.1.4(solid-js@1.9.14)
+      '@solid-primitives/i18n':
+        specifier: ^2.2.1
+        version: 2.2.1(solid-js@1.9.14)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -77,10 +80,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.8
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
 
   web/docs:
     dependencies:
@@ -133,6 +136,9 @@ importers:
       '@regenfass/brand':
         specifier: workspace:*
         version: link:../brand
+      '@solid-primitives/i18n':
+        specifier: ^2.2.1
+        version: 2.2.1(solid-js@1.9.14)
       '@solidjs/router':
         specifier: ^0.15.3
         version: 0.15.4(solid-js@1.9.14)
@@ -281,6 +287,9 @@ importers:
       '@regenfass/brand':
         specifier: workspace:*
         version: link:../brand
+      '@solid-primitives/i18n':
+        specifier: ^2.2.1
+        version: 2.2.1(solid-js@1.9.14)
       '@solidjs/router':
         specifier: ^0.15.3
         version: 0.15.4(solid-js@1.9.14)
@@ -308,10 +317,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.5
-        version: 7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0)
+        version: 7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.8
-        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@2.6.1)(tsx@4.23.1)(yaml@2.9.0))
+        version: 2.11.12(@testing-library/jest-dom@6.9.1)(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -908,6 +917,11 @@ packages:
 
   '@solid-primitives/event-listener@2.4.6':
     resolution: {integrity: sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/i18n@2.2.1':
+    resolution: {integrity: sha512-TnTnE2Ku11MGYZ1JzhJ8pYscwg1fr9MteoYxPwsfxWfh9Jp5K7RRJncJn9BhOHvNLwROjqOHZ46PT7sPHqbcXw==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -3273,6 +3287,10 @@ snapshots:
   '@solid-primitives/event-listener@2.4.6(solid-js@1.9.14)':
     dependencies:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.14)
+      solid-js: 1.9.14
+
+  '@solid-primitives/i18n@2.2.1(solid-js@1.9.14)':
+    dependencies:
       solid-js: 1.9.14
 
   '@solid-primitives/keyed@1.5.3(solid-js@1.9.14)':

--- a/web/brand/package.json
+++ b/web/brand/package.json
@@ -9,12 +9,13 @@
     "./tailwind.preset.cjs": "./tailwind.preset.cjs"
   },
   "peerDependencies": {
-    "solid-js": "^1.9.0",
+    "@kobalte/core": "^0.13.0",
     "@solidjs/router": "^0.15.0",
-    "@kobalte/core": "^0.13.0"
+    "solid-js": "^1.9.0"
   },
   "dependencies": {
     "@corvu/otp-field": "^0.1.4",
+    "@solid-primitives/i18n": "^2.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-solid": "^0.543.0",

--- a/web/brand/src/components/atoms/ButtonModeToggle.tsx
+++ b/web/brand/src/components/atoms/ButtonModeToggle.tsx
@@ -3,9 +3,11 @@ import Moon from "lucide-solid/icons/moon";
 import Sun from "lucide-solid/icons/sun";
 import { useColorMode } from "@kobalte/core/color-mode";
 import { trackEvent } from "../../libs/analytics.ts";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export function ButtonModeToggle() {
 	const { colorMode, setColorMode } = useColorMode();
+	const t = useBrandT();
 
 	const toggle = () => {
 		const next = colorMode() === "light" ? "dark" : "light";
@@ -24,7 +26,7 @@ export function ButtonModeToggle() {
 		<Button
 			variant="ghost"
 			size="icon"
-			aria-label="Toggle color mode"
+			aria-label={t("a11y.toggleColorMode")}
 			onClick={toggle}
 			class="transition-transform duration-200 active:scale-95 text-foreground/80 hover:text-foreground"
 		>

--- a/web/brand/src/components/atoms/ButtonSoundToggle.tsx
+++ b/web/brand/src/components/atoms/ButtonSoundToggle.tsx
@@ -2,9 +2,12 @@ import { Button } from "./Button.tsx";
 import { soundEnabled, toggleSoundEnabled } from "../../libs/soundPreference.ts";
 import { BiRegularVolumeFull, BiRegularVolumeMute } from "solid-icons/bi";
 import { Show } from "solid-js";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export function ButtonSoundToggle() {
-	const label = () => (soundEnabled() ? "Mute sounds" : "Unmute sounds");
+	const t = useBrandT();
+	const label = () =>
+		soundEnabled() ? t("a11y.muteSounds") : t("a11y.unmuteSounds");
 
 	return (
 		<Button

--- a/web/brand/src/components/atoms/Spinner.tsx
+++ b/web/brand/src/components/atoms/Spinner.tsx
@@ -2,6 +2,7 @@ import { cn } from "../../libs/cn.ts";
 import LoaderCircle from "lucide-solid/icons/loader-circle";
 import type { ComponentProps } from "solid-js";
 import { splitProps } from "solid-js";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export interface SpinnerProps extends ComponentProps<"svg"> {
 	size?: "sm" | "md" | "lg";
@@ -9,6 +10,7 @@ export interface SpinnerProps extends ComponentProps<"svg"> {
 
 export const Spinner = (props: SpinnerProps) => {
 	const [local, rest] = splitProps(props, ["class", "size"]);
+	const t = useBrandT();
 
 	const sizeClasses = {
 		sm: "size-3",
@@ -19,7 +21,7 @@ export const Spinner = (props: SpinnerProps) => {
 	return (
 		<LoaderCircle
 			role="status"
-			aria-label="Loading"
+			aria-label={t("a11y.loading")}
 			class={cn("animate-spin", sizeClasses[local.size ?? "md"], local.class)}
 			{...rest}
 		/>

--- a/web/brand/src/components/forms/AppKeyHexField.tsx
+++ b/web/brand/src/components/forms/AppKeyHexField.tsx
@@ -16,6 +16,7 @@ import EyeOff from "lucide-solid/icons/eye-off";
 import { BiRegularClipboard, BiRegularX } from "solid-icons/bi";
 import type { Component } from "solid-js";
 import { For, Show, createSignal, onCleanup, onMount } from "solid-js";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export interface AppKeyHexFieldProps {
 	id: string;
@@ -107,6 +108,7 @@ const APP_KEY_HEX_COLUMNS_CLASS = "w-[36rem]";
 
 /** Single-line AppKey editor: bullet mask + vertical reel columns (wheel spin + overshoot) on reveal + chime. */
 export const AppKeyHexField: Component<AppKeyHexFieldProps> = (props) => {
+	const t = useBrandT();
 	const [revealed, setRevealed] = createSignal(false);
 	const [spinning, setSpinning] = createSignal(false);
 	const [reelMatrix, setReelMatrix] = createSignal<string[][] | null>(null);
@@ -193,7 +195,7 @@ export const AppKeyHexField: Component<AppKeyHexFieldProps> = (props) => {
 	};
 
 	const copyLabel = () =>
-		copied() ? "Copied appKey" : "Copy appKey to clipboard";
+		copied() ? t("a11y.copiedAppKey") : t("a11y.copyAppKey");
 
 	const copyToClipboard = async () => {
 		const canonical = props.value ?? "";
@@ -299,7 +301,7 @@ export const AppKeyHexField: Component<AppKeyHexFieldProps> = (props) => {
 					type="button"
 					disabled={spinInProgress()}
 					class="flex h-10 w-10 shrink-0 items-center justify-center border-l border-input text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50"
-					aria-label="Clear appKey"
+					aria-label={t("a11y.clearAppKey")}
 					onClick={handleReset}
 				>
 					<BiRegularX aria-hidden={true} size={16} />
@@ -311,7 +313,7 @@ export const AppKeyHexField: Component<AppKeyHexFieldProps> = (props) => {
 				class="flex h-10 w-10 shrink-0 items-center justify-center border-l border-input text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50"
 				aria-pressed={revealed()}
 				aria-busy={spinInProgress()}
-				aria-label={revealed() ? "Hide app key" : "Show app key"}
+				aria-label={revealed() ? t("a11y.hideAppKey") : t("a11y.showAppKey")}
 				onClick={handleToggleReveal}
 			>
 				<Show when={revealed()} fallback={<Eye class="size-4" strokeWidth={1.75} />}>

--- a/web/brand/src/components/forms/FileUploader.tsx
+++ b/web/brand/src/components/forms/FileUploader.tsx
@@ -1,85 +1,99 @@
-import { Component, JSX, splitProps, createSignal } from "solid-js";
+import { Component, For, Show, JSX, splitProps, createSignal } from "solid-js";
 import { FormField } from "./FormField";
 import { Button } from "../atoms/Button.tsx";
 import { cn } from "../../libs/cn.ts";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
-export interface FileUploaderProps extends Omit<JSX.InputHTMLAttributes<HTMLInputElement>, 'type' | 'class'> {
-  label?: string;
-  required?: boolean;
-  error?: string;
-  helperText?: string;
-  class?: string;
-  accept?: string;
-  multiple?: boolean;
-  onFileSelect?: (files: FileList | null) => void;
+export interface FileUploaderProps
+	extends Omit<JSX.InputHTMLAttributes<HTMLInputElement>, "type" | "class"> {
+	label?: string;
+	required?: boolean;
+	error?: string;
+	helperText?: string;
+	class?: string;
+	accept?: string;
+	multiple?: boolean;
+	onFileSelect?: (files: FileList | null) => void;
 }
 
 const FileUploader: Component<FileUploaderProps> = (props) => {
-  const [local, rest] = splitProps(props, ["label", "required", "error", "helperText", "class", "accept", "multiple", "onFileSelect"]);
-  const [selectedFiles, setSelectedFiles] = createSignal<FileList | null>(null);
+	const [local, rest] = splitProps(props, [
+		"label",
+		"required",
+		"error",
+		"helperText",
+		"class",
+		"accept",
+		"multiple",
+		"onFileSelect",
+	]);
+	const [selectedFiles, setSelectedFiles] = createSignal<FileList | null>(null);
+	const t = useBrandT();
+	const inputId = `file-${Math.random().toString(36).slice(2, 11)}`;
 
-  const handleFileChange = (event: Event) => {
-    const target = event.target as HTMLInputElement;
-    const files = target.files;
-    setSelectedFiles(files);
-    local.onFileSelect?.(files);
-  };
+	const handleFileChange = (event: Event) => {
+		const target = event.target as HTMLInputElement;
+		const files = target.files;
+		setSelectedFiles(files);
+		local.onFileSelect?.(files);
+	};
 
-  const clearFiles = () => {
-    setSelectedFiles(null);
-    local.onFileSelect?.(null);
-  };
+	const clearFiles = () => {
+		setSelectedFiles(null);
+		local.onFileSelect?.(null);
+	};
 
-  return (
-    <FormField
-      label={local.label}
-      required={local.required}
-      error={local.error}
-      helperText={local.helperText}
-    >
-      <div class={cn("space-y-3", local.class)}>
-        <div class="flex items-center space-x-3">
-          <input
-            {...rest}
-            type="file"
-            accept={local.accept}
-            multiple={local.multiple}
-            onChange={handleFileChange}
-            class="hidden"
-            id={`file-${Math.random().toString(36).substr(2, 9)}`}
-          />
-          <label
-            for={`file-${Math.random().toString(36).substr(2, 9)}`}
-            class="cursor-pointer"
-          >
-            <Button type="button" variant="outline">
-              Datei auswählen
-            </Button>
-          </label>
-          {selectedFiles() && (
-            <Button type="button" variant="ghost" onClick={clearFiles}>
-              Löschen
-            </Button>
-          )}
-        </div>
+	return (
+		<FormField
+			label={local.label}
+			required={local.required}
+			error={local.error}
+			helperText={local.helperText}
+		>
+			<div class={cn("space-y-3", local.class)}>
+				<div class="flex items-center space-x-3">
+					<input
+						{...rest}
+						type="file"
+						accept={local.accept}
+						multiple={local.multiple}
+						onChange={handleFileChange}
+						class="hidden"
+						id={inputId}
+					/>
+					<label for={inputId} class="cursor-pointer">
+						<Button type="button" variant="outline">
+							{t("fileUploader.selectFile")}
+						</Button>
+					</label>
+					<Show when={selectedFiles()}>
+						<Button type="button" variant="ghost" onClick={clearFiles}>
+							{t("fileUploader.clear")}
+						</Button>
+					</Show>
+				</div>
 
-        {selectedFiles() && (
-          <div class="space-y-2">
-            <p class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Ausgewählte Dateien:
-            </p>
-            <ul class="space-y-1">
-              {Array.from(selectedFiles()!).map((file) => (
-                <li class="text-sm text-gray-600 dark:text-gray-400">
-                  {file.name} ({(file.size / 1024).toFixed(1)} KB)
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-    </FormField>
-  );
+				<Show when={selectedFiles()}>
+					{(files) => (
+						<div class="space-y-2">
+							<p class="text-sm font-medium text-gray-700 dark:text-gray-300">
+								{t("fileUploader.selectedFiles")}
+							</p>
+							<ul class="space-y-1">
+								<For each={Array.from(files())}>
+									{(file) => (
+										<li class="text-sm text-gray-600 dark:text-gray-400">
+											{file.name} ({(file.size / 1024).toFixed(1)} KB)
+										</li>
+									)}
+								</For>
+							</ul>
+						</div>
+					)}
+				</Show>
+			</div>
+		</FormField>
+	);
 };
 
 export { FileUploader };

--- a/web/brand/src/components/molecules/ErrorList.tsx
+++ b/web/brand/src/components/molecules/ErrorList.tsx
@@ -1,46 +1,48 @@
-import { Component, For, JSX } from "solid-js";
+import { Component, For, Show, splitProps, type JSX } from "solid-js";
 import { cn } from "../../libs/cn.ts";
 import XCircle from "lucide-solid/icons/x-circle";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export interface ErrorListProps extends JSX.HTMLAttributes<HTMLDivElement> {
-  errors?: string[];
-  title?: string;
+	errors?: string[];
+	title?: string;
 }
 
 const ErrorList: Component<ErrorListProps> = (props) => {
-  const { errors = [], title = "Fehler", class: className, ...rest } = props;
-
-  if (errors.length === 0) return null;
+	const [local, rest] = splitProps(props, ["errors", "title", "class"]);
+	const t = useBrandT();
+	const errors = () => local.errors ?? [];
+	const title = () => local.title ?? t("errors.title");
 
 	return (
-    <div
-      class={cn(
-        "rounded-md border border-destructive/30 bg-destructive/10 p-4",
-        "dark:border-destructive/70 dark:bg-destructive/25",
-        className
-      )}
-      role="alert"
-      {...rest}
-    >
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <XCircle class="h-5 w-5 text-destructive dark:text-destructive-foreground" />
-        </div>
-        <div class="ml-3">
-          <h3 class="text-sm font-medium text-destructive dark:text-destructive-foreground">
-            {title}
-          </h3>
-          <div class="mt-2 text-sm text-destructive dark:text-destructive-foreground/90">
-            <ul class="list-disc pl-5 space-y-1">
-              <For each={errors}>
-                {(error) => <li>{error}</li>}
-              </For>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+		<Show when={errors().length > 0}>
+			<div
+				class={cn(
+					"rounded-md border border-destructive/30 bg-destructive/10 p-4",
+					"dark:border-destructive/70 dark:bg-destructive/25",
+					local.class,
+				)}
+				role="alert"
+				{...rest}
+			>
+				<div class="flex">
+					<div class="flex-shrink-0">
+						<XCircle class="h-5 w-5 text-destructive dark:text-destructive-foreground" />
+					</div>
+					<div class="ml-3">
+						<h3 class="text-sm font-medium text-destructive dark:text-destructive-foreground">
+							{title()}
+						</h3>
+						<div class="mt-2 text-sm text-destructive dark:text-destructive-foreground/90">
+							<ul class="list-disc pl-5 space-y-1">
+								<For each={errors()}>{(error) => <li>{error}</li>}</For>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+		</Show>
+	);
 };
 
 export { ErrorList };

--- a/web/brand/src/components/organisms/Footer.tsx
+++ b/web/brand/src/components/organisms/Footer.tsx
@@ -2,8 +2,11 @@ import Book from "lucide-solid/icons/book";
 import Github from "lucide-solid/icons/github";
 import MessageSquare from "lucide-solid/icons/message-square";
 import { APP_VERSION } from "../../version.ts";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export default function Footer() {
+	const t = useBrandT();
+
 	return (
 		<footer class="site-container py-6">
 			<div class="pt-5 text-xs sm:text-sm  antialiased text-gray-400 border-t border-gray-300 dark:border-gray-00 dark:text-gray-400">
@@ -11,21 +14,30 @@ export default function Footer() {
 				<nav class="md:hidden mb-4">
 					<ul class="flex font-medium text-gray-800 gap-x-3 dark:text-gray-400">
 						<li>
-							<a href="https://docs.regenfass.eu/" class="p-2 inline-flex items-center gap-1 hover:text-slate-500 dark:hover:text-white hover:underline">
+							<a
+								href="https://docs.regenfass.eu/"
+								class="p-2 inline-flex items-center gap-1 hover:text-slate-500 dark:hover:text-white hover:underline"
+							>
 								<Book size={18} />
-								<span>Docs</span>
+								<span>{t("footer.docs")}</span>
 							</a>
 						</li>
 						<li>
-							<a href="https://github.com/ttnleipzig/regenfass" class="p-2 inline-flex items-center gap-1 hover:text-slate-500 dark:hover:text-white hover:underline">
+							<a
+								href="https://github.com/ttnleipzig/regenfass"
+								class="p-2 inline-flex items-center gap-1 hover:text-slate-500 dark:hover:text-white hover:underline"
+							>
 								<Github size={18} />
-								<span>GitHub</span>
+								<span>{t("footer.github")}</span>
 							</a>
 						</li>
 						<li>
-							<a href="https://matrix.to/#/#ttn-leipzig:matrix.org" class="p-2 inline-flex items-center gap-1 hover:text-slate-500 dark:hover:text-white hover:underline">
+							<a
+								href="https://matrix.to/#/#ttn-leipzig:matrix.org"
+								class="p-2 inline-flex items-center gap-1 hover:text-slate-500 dark:hover:text-white hover:underline"
+							>
 								<MessageSquare size={18} />
-								<span>Matrix</span>
+								<span>{t("footer.matrix")}</span>
 							</a>
 						</li>
 					</ul>
@@ -35,7 +47,7 @@ export default function Footer() {
 					Germany, Europe, United Nations, Milky Way
 				</address>
 				<p>
-					Powered by{" "}
+					{t("footer.poweredBy")}{" "}
 					<a
 						href="https://esphome.github.io/esp-web-tools/"
 						target="_blank"
@@ -54,7 +66,7 @@ export default function Footer() {
 						rel="noopener noreferrer"
 						class="hover:text-slate-500 dark:hover:text-white hover:underline"
 					>
-						Release notes
+						{t("footer.releaseNotes")}
 					</a>
 				</p>
 			</div>

--- a/web/brand/src/components/organisms/Header.tsx
+++ b/web/brand/src/components/organisms/Header.tsx
@@ -2,6 +2,7 @@ import { Component, For, Show, mergeProps, type JSX } from "solid-js";
 import { A } from "@solidjs/router";
 import { ButtonModeToggle } from "../atoms/ButtonModeToggle.tsx";
 import Link from "../atoms/Link.tsx";
+import { LanguageSwitcher } from "../../i18n/LanguageSwitcher.tsx";
 import { cn } from "../../libs/cn.ts";
 
 export type HeaderNavItem = {
@@ -80,6 +81,7 @@ const Header: Component<HeaderProps> = (rawProps) => {
 
         <div class="flex items-center gap-1">
           {props.trailing}
+          <LanguageSwitcher />
           <ButtonModeToggle />
         </div>
       </div>

--- a/web/brand/src/components/organisms/Newsletter.tsx
+++ b/web/brand/src/components/organisms/Newsletter.tsx
@@ -5,22 +5,22 @@ import {
 	TextFieldInput,
 } from "../forms/TextField.tsx";
 import { cn } from "../../libs/cn.ts";
+import { useBrandT } from "../../i18n/LocaleProvider.tsx";
 
 export default function Newsletter() {
+	const t = useBrandT();
+
 	return (
 		<aside id="newsletter" class="site-container py-6">
 			<div class="flex flex-col items-center justify-between gap-6 sm:flex-row">
 				<div class="sm:w-7/12">
 					<Headline as="h2">
-						Subscribe to the
+						{t("newsletter.titleBefore")}{" "}
 						<span class="text-transparent bg-gradient-to-br from-sky-500 to-cyan-400 bg-clip-text">
-							update newsletters
+							{t("newsletter.titleHighlight")}
 						</span>
 					</Headline>
-					<p class="mt-3 text-muted-foreground">
-						If you would like to be informed about software updates,
-						you can subscribe to this newsletter.
-					</p>
+					<p class="mt-3 text-muted-foreground">{t("newsletter.body")}</p>
 				</div>
 				<div class="w-full sm:w-5/12">
 					<form
@@ -29,14 +29,14 @@ export default function Newsletter() {
 							"flex px-4 py-2 bg-background rounded-full",
 							"focus-within:ring-2 focus-within:ring-ring",
 							"hover:ring-2 hover:ring-ring/50",
-							"border border-input"
+							"border border-input",
 						)}
 					>
 						<TextFieldRoot class="flex-1">
 							<TextFieldInput
 								type="email"
 								class="w-full appearance-none bg-transparent focus:outline-none border-0"
-								placeholder="your@email-address.iot"
+								placeholder={t("newsletter.placeholder")}
 							/>
 						</TextFieldRoot>
 						<Button
@@ -44,7 +44,7 @@ export default function Newsletter() {
 							class="px-3 py-1 ml-2 text-sm font-semibold rounded-full shrink-0 bg-gradient-to-br from-sky-500 to-cyan-400 hover:from-sky-700 hover:to-cyan-600 text-white"
 							type="submit"
 						>
-							Subscribe
+							{t("newsletter.subscribe")}
 						</Button>
 					</form>
 				</div>

--- a/web/brand/src/i18n/LanguageSwitcher.tsx
+++ b/web/brand/src/i18n/LanguageSwitcher.tsx
@@ -1,0 +1,60 @@
+import { For } from "solid-js";
+import { Button } from "../components/atoms/Button.tsx";
+import { cn } from "../libs/cn.ts";
+import { LOCALES, type Locale } from "./types.ts";
+import { useLocaleOptional } from "./LocaleProvider.tsx";
+
+const LABELS: Record<Locale, string> = {
+	de: "DE",
+	en: "EN",
+};
+
+/**
+ * Compact DE | EN control. Renders nothing outside LocaleProvider.
+ */
+export function LanguageSwitcher() {
+	const ctx = useLocaleOptional();
+	if (!ctx) return null;
+
+	const { locale, setLocale, t } = ctx;
+
+	const ariaFor = (code: Locale) =>
+		code === "de" ? t("header.switchToDe") : t("header.switchToEn");
+
+	return (
+		<div
+			role="group"
+			aria-label={t("header.language")}
+			class="flex items-center text-sm font-medium text-foreground/70"
+		>
+			<For each={[...LOCALES]}>
+				{(code, index) => (
+					<span class="contents">
+						{index() > 0 ? (
+							<span aria-hidden="true" class="px-0.5 text-foreground/40">
+								|
+							</span>
+						) : null}
+						<Button
+							variant="ghost"
+							size="sm"
+							aria-label={ariaFor(code)}
+							aria-pressed={locale() === code}
+							onClick={() => {
+								if (locale() !== code) setLocale(code);
+							}}
+							class={cn(
+								"h-8 min-w-8 px-1.5 transition-transform duration-200 active:scale-95",
+								locale() === code
+									? "text-foreground font-semibold"
+									: "text-foreground/60 hover:text-foreground",
+							)}
+						>
+							{LABELS[code]}
+						</Button>
+					</span>
+				)}
+			</For>
+		</div>
+	);
+}

--- a/web/brand/src/i18n/LocaleProvider.tsx
+++ b/web/brand/src/i18n/LocaleProvider.tsx
@@ -1,0 +1,107 @@
+import {
+	createContext,
+	createEffect,
+	createMemo,
+	createSignal,
+	useContext,
+	type Accessor,
+	type ParentComponent,
+} from "solid-js";
+import {
+	flatten,
+	resolveTemplate,
+	translator,
+	type Translator,
+} from "@solid-primitives/i18n";
+import {
+	brandDictionaries,
+	type FlatBrandDictionary,
+} from "./dictionaries/index.ts";
+import {
+	resolveLocale,
+	writeLocaleCookie,
+} from "./preference.ts";
+import { DEFAULT_LOCALE, isLocale, type Locale } from "./types.ts";
+
+export type SetLocaleOptions = {
+	/** When false, skip onLocaleChange (e.g. syncing from the marketing URL). Default true. */
+	announce?: boolean;
+};
+
+export type LocaleContextValue = {
+	locale: Accessor<Locale>;
+	setLocale: (next: Locale, options?: SetLocaleOptions) => void;
+	t: Translator<FlatBrandDictionary>;
+};
+
+const LocaleContext = createContext<LocaleContextValue>();
+
+export type LocaleProviderProps = {
+	/** Initial locale; defaults to cookie → browser → en. */
+	initialLocale?: Locale;
+	/** Called after locale changes (e.g. marketing URL navigation). */
+	onLocaleChange?: (locale: Locale) => void;
+};
+
+function applyDocumentLang(locale: Locale) {
+	if (typeof document === "undefined") return;
+	document.documentElement.lang = locale;
+}
+
+export const LocaleProvider: ParentComponent<LocaleProviderProps> = (props) => {
+	const initial =
+		props.initialLocale && isLocale(props.initialLocale)
+			? props.initialLocale
+			: resolveLocale();
+	const [locale, setLocaleSignal] = createSignal<Locale>(initial);
+
+	createEffect(() => {
+		applyDocumentLang(locale());
+	});
+
+	const dict = createMemo(() => flatten(brandDictionaries[locale()]));
+	const t = translator(dict, resolveTemplate);
+
+	const setLocale = (next: Locale, options?: SetLocaleOptions) => {
+		if (!isLocale(next)) return;
+		const announce = options?.announce !== false;
+		setLocaleSignal(next);
+		writeLocaleCookie(next);
+		applyDocumentLang(next);
+		if (announce) {
+			props.onLocaleChange?.(next);
+		}
+	};
+
+	const value: LocaleContextValue = {
+		locale,
+		setLocale,
+		t,
+	};
+
+	return (
+		<LocaleContext.Provider value={value}>
+			{props.children}
+		</LocaleContext.Provider>
+	);
+};
+
+export function useLocale(): LocaleContextValue {
+	const ctx = useContext(LocaleContext);
+	if (!ctx) {
+		throw new Error("useLocale must be used within a LocaleProvider");
+	}
+	return ctx;
+}
+
+/** Returns brand translator; falls back to English outside LocaleProvider (tests). */
+export function useBrandT(): Translator<FlatBrandDictionary> {
+	const ctx = useContext(LocaleContext);
+	if (ctx) return ctx.t;
+	const dict = () => flatten(brandDictionaries[DEFAULT_LOCALE]);
+	return translator(dict, resolveTemplate);
+}
+
+export function useLocaleOptional(): LocaleContextValue | undefined {
+	return useContext(LocaleContext);
+}

--- a/web/brand/src/i18n/dictionaries/de.ts
+++ b/web/brand/src/i18n/dictionaries/de.ts
@@ -1,0 +1,42 @@
+import type { BrandDictionary } from "./en.ts";
+
+export const brandDictDe: BrandDictionary = {
+	header: {
+		switchToDe: "Zu Deutsch wechseln",
+		switchToEn: "Zu Englisch wechseln",
+		language: "Sprache",
+	},
+	footer: {
+		docs: "Docs",
+		github: "GitHub",
+		matrix: "Matrix",
+		poweredBy: "Bereitgestellt mit",
+		releaseNotes: "Release Notes",
+	},
+	newsletter: {
+		titleBefore: "Abonniere den",
+		titleHighlight: "Update-Newsletter",
+		body: "Wenn du über Software-Updates informiert werden möchtest, kannst du diesen Newsletter abonnieren.",
+		placeholder: "deine@email-adresse.iot",
+		subscribe: "Abonnieren",
+	},
+	a11y: {
+		toggleColorMode: "Farbmodus umschalten",
+		muteSounds: "Töne stummschalten",
+		unmuteSounds: "Töne aktivieren",
+		loading: "Lädt",
+		copyAppKey: "AppKey in die Zwischenablage kopieren",
+		copiedAppKey: "AppKey kopiert",
+		clearAppKey: "AppKey löschen",
+		showAppKey: "App-Key anzeigen",
+		hideAppKey: "App-Key verbergen",
+	},
+	errors: {
+		title: "Fehler",
+	},
+	fileUploader: {
+		selectFile: "Datei auswählen",
+		clear: "Löschen",
+		selectedFiles: "Ausgewählte Dateien:",
+	},
+};

--- a/web/brand/src/i18n/dictionaries/en.ts
+++ b/web/brand/src/i18n/dictionaries/en.ts
@@ -1,4 +1,45 @@
-export const brandDictEn = {
+export type BrandDictionary = {
+	header: {
+		switchToDe: string;
+		switchToEn: string;
+		language: string;
+	};
+	footer: {
+		docs: string;
+		github: string;
+		matrix: string;
+		poweredBy: string;
+		releaseNotes: string;
+	};
+	newsletter: {
+		titleBefore: string;
+		titleHighlight: string;
+		body: string;
+		placeholder: string;
+		subscribe: string;
+	};
+	a11y: {
+		toggleColorMode: string;
+		muteSounds: string;
+		unmuteSounds: string;
+		loading: string;
+		copyAppKey: string;
+		copiedAppKey: string;
+		clearAppKey: string;
+		showAppKey: string;
+		hideAppKey: string;
+	};
+	errors: {
+		title: string;
+	};
+	fileUploader: {
+		selectFile: string;
+		clear: string;
+		selectedFiles: string;
+	};
+};
+
+export const brandDictEn: BrandDictionary = {
 	header: {
 		switchToDe: "Switch to German",
 		switchToEn: "Switch to English",
@@ -37,6 +78,4 @@ export const brandDictEn = {
 		clear: "Clear",
 		selectedFiles: "Selected files:",
 	},
-} as const;
-
-export type BrandDictionary = typeof brandDictEn;
+};

--- a/web/brand/src/i18n/dictionaries/en.ts
+++ b/web/brand/src/i18n/dictionaries/en.ts
@@ -1,0 +1,42 @@
+export const brandDictEn = {
+	header: {
+		switchToDe: "Switch to German",
+		switchToEn: "Switch to English",
+		language: "Language",
+	},
+	footer: {
+		docs: "Docs",
+		github: "GitHub",
+		matrix: "Matrix",
+		poweredBy: "Powered by",
+		releaseNotes: "Release notes",
+	},
+	newsletter: {
+		titleBefore: "Subscribe to the",
+		titleHighlight: "update newsletters",
+		body: "If you would like to be informed about software updates, you can subscribe to this newsletter.",
+		placeholder: "your@email-address.iot",
+		subscribe: "Subscribe",
+	},
+	a11y: {
+		toggleColorMode: "Toggle color mode",
+		muteSounds: "Mute sounds",
+		unmuteSounds: "Unmute sounds",
+		loading: "Loading",
+		copyAppKey: "Copy appKey to clipboard",
+		copiedAppKey: "Copied appKey",
+		clearAppKey: "Clear appKey",
+		showAppKey: "Show app key",
+		hideAppKey: "Hide app key",
+	},
+	errors: {
+		title: "Errors",
+	},
+	fileUploader: {
+		selectFile: "Select file",
+		clear: "Clear",
+		selectedFiles: "Selected files:",
+	},
+} as const;
+
+export type BrandDictionary = typeof brandDictEn;

--- a/web/brand/src/i18n/dictionaries/index.ts
+++ b/web/brand/src/i18n/dictionaries/index.ts
@@ -1,0 +1,18 @@
+import { flatten, type Flatten } from "@solid-primitives/i18n";
+import type { Locale } from "../types.ts";
+import { brandDictDe } from "./de.ts";
+import { brandDictEn, type BrandDictionary } from "./en.ts";
+
+export type { BrandDictionary };
+export { brandDictDe, brandDictEn };
+
+export const brandDictionaries: Record<Locale, BrandDictionary> = {
+	de: brandDictDe,
+	en: brandDictEn,
+};
+
+export type FlatBrandDictionary = Flatten<BrandDictionary>;
+
+export function flatBrandDictionary(locale: Locale): FlatBrandDictionary {
+	return flatten(brandDictionaries[locale]);
+}

--- a/web/brand/src/i18n/index.ts
+++ b/web/brand/src/i18n/index.ts
@@ -1,0 +1,34 @@
+export {
+	DEFAULT_LOCALE,
+	isLocale,
+	LOCALE_COOKIE_NAME,
+	LOCALES,
+	type Locale,
+} from "./types.ts";
+export {
+	clearLocaleCookie,
+	cookieDomainForHost,
+	detectBrowserLocale,
+	parseLocaleFromCookieString,
+	readLocaleCookie,
+	resetLocalePreferenceForTests,
+	resolveLocale,
+	writeLocaleCookie,
+} from "./preference.ts";
+export {
+	LocaleProvider,
+	useBrandT,
+	useLocale,
+	useLocaleOptional,
+	type LocaleContextValue,
+	type LocaleProviderProps,
+} from "./LocaleProvider.tsx";
+export { LanguageSwitcher } from "./LanguageSwitcher.tsx";
+export {
+	brandDictDe,
+	brandDictEn,
+	brandDictionaries,
+	flatBrandDictionary,
+	type BrandDictionary,
+	type FlatBrandDictionary,
+} from "./dictionaries/index.ts";

--- a/web/brand/src/i18n/preference.ts
+++ b/web/brand/src/i18n/preference.ts
@@ -1,0 +1,107 @@
+import {
+	DEFAULT_LOCALE,
+	isLocale,
+	LOCALE_COOKIE_NAME,
+	type Locale,
+} from "./types.ts";
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/** Cookie Domain for production hosts under regenfass.eu; omit on localhost / Netlify previews. */
+export function cookieDomainForHost(hostname: string): string | undefined {
+	const host = hostname.toLowerCase();
+	if (host === "regenfass.eu" || host.endsWith(".regenfass.eu")) {
+		return ".regenfass.eu";
+	}
+	return undefined;
+}
+
+export function parseLocaleFromCookieString(
+	cookieHeader: string | undefined | null,
+): Locale | null {
+	if (!cookieHeader) return null;
+	const parts = cookieHeader.split(";");
+	for (const part of parts) {
+		const [rawName, ...rest] = part.trim().split("=");
+		if (rawName !== LOCALE_COOKIE_NAME) continue;
+		const value = decodeURIComponent(rest.join("=").trim());
+		if (isLocale(value)) return value;
+	}
+	return null;
+}
+
+export function readLocaleCookie(): Locale | null {
+	if (typeof document === "undefined") return null;
+	try {
+		return parseLocaleFromCookieString(document.cookie);
+	} catch {
+		return null;
+	}
+}
+
+export function writeLocaleCookie(locale: Locale): void {
+	if (typeof document === "undefined") return;
+	try {
+		const secure =
+			typeof location !== "undefined" && location.protocol === "https:"
+				? "; Secure"
+				: "";
+		const domain = cookieDomainForHost(
+			typeof location !== "undefined" ? location.hostname : "",
+		);
+		const domainAttr = domain ? `; Domain=${domain}` : "";
+		document.cookie = `${LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${domainAttr}${secure}`;
+	} catch {
+		/* restrictive environments */
+	}
+}
+
+export function clearLocaleCookie(): void {
+	if (typeof document === "undefined") return;
+	try {
+		const domain = cookieDomainForHost(
+			typeof location !== "undefined" ? location.hostname : "",
+		);
+		const domainAttr = domain ? `; Domain=${domain}` : "";
+		document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax${domainAttr}`;
+		// Also clear host-only variant from older sessions / local dev
+		document.cookie = `${LOCALE_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
+	} catch {
+		/* ignore */
+	}
+}
+
+export function detectBrowserLocale(
+	languages: readonly string[] | undefined = typeof navigator !== "undefined"
+		? navigator.languages?.length
+			? navigator.languages
+			: navigator.language
+				? [navigator.language]
+				: []
+		: [],
+): Locale {
+	for (const tag of languages) {
+		const lower = tag.toLowerCase();
+		if (lower === "de" || lower.startsWith("de-")) return "de";
+		if (lower === "en" || lower.startsWith("en-")) return "en";
+	}
+	return DEFAULT_LOCALE;
+}
+
+/** Cookie override → browser languages → English. */
+export function resolveLocale(
+	cookieHeader?: string | null,
+	languages?: readonly string[],
+): Locale {
+	const fromCookie =
+		cookieHeader === undefined
+			? readLocaleCookie()
+			: parseLocaleFromCookieString(cookieHeader);
+	if (fromCookie) return fromCookie;
+	return detectBrowserLocale(languages);
+}
+
+/** @internal Reset preference between tests. */
+export function resetLocalePreferenceForTests(): void {
+	clearLocaleCookie();
+}

--- a/web/brand/src/i18n/types.ts
+++ b/web/brand/src/i18n/types.ts
@@ -1,0 +1,11 @@
+export const LOCALES = ["de", "en"] as const;
+
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+export const LOCALE_COOKIE_NAME = "regenfass-locale";
+
+export function isLocale(value: string | null | undefined): value is Locale {
+	return value === "de" || value === "en";
+}

--- a/web/brand/src/index.ts
+++ b/web/brand/src/index.ts
@@ -58,6 +58,38 @@ export { default as Newsletter } from "./components/organisms/Newsletter.tsx";
 
 export { APP_VERSION } from "./version.ts";
 
+// i18n
+export {
+  DEFAULT_LOCALE,
+  isLocale,
+  LOCALE_COOKIE_NAME,
+  LOCALES,
+  clearLocaleCookie,
+  cookieDomainForHost,
+  detectBrowserLocale,
+  parseLocaleFromCookieString,
+  readLocaleCookie,
+  resetLocalePreferenceForTests,
+  resolveLocale,
+  writeLocaleCookie,
+  LocaleProvider,
+  useBrandT,
+  useLocale,
+  useLocaleOptional,
+  LanguageSwitcher,
+  brandDictDe,
+  brandDictEn,
+  brandDictionaries,
+  flatBrandDictionary,
+} from "./i18n/index.ts";
+export type {
+  Locale,
+  LocaleContextValue,
+  LocaleProviderProps,
+  BrandDictionary,
+  FlatBrandDictionary,
+} from "./i18n/index.ts";
+
 // Forms
 export { AppKeyHexField } from "./components/forms/AppKeyHexField.tsx";
 export type { AppKeyHexFieldProps } from "./components/forms/AppKeyHexField.tsx";

--- a/web/installer/docs/COMPONENTS.md
+++ b/web/installer/docs/COMPONENTS.md
@@ -331,4 +331,4 @@ import { TextInput } from '@regenfass/brand';
 
 ---
 
-*Generated on July 14, 2026 at 07:15 PM*
+*Generated on July 16, 2026 at 01:18 PM*

--- a/web/installer/docs/README.md
+++ b/web/installer/docs/README.md
@@ -272,7 +272,7 @@ Configuration can be exported to and imported from JSON files:
 
 ### Error Messages
 
-All error messages are localized in German and provide:
+User-facing error messages follow the active locale (German or English) and provide:
 
 - Clear problem description
 - Specific recovery steps

--- a/web/installer/docs/components/molecules/error-list.md
+++ b/web/installer/docs/components/molecules/error-list.md
@@ -5,28 +5,28 @@ Display multiple form errors in a visually distinct alert box.
 ```tsx
 import { ErrorList } from '@/components/forms/ErrorList';
 
-<ErrorList title='Fehler' errors={['AppKey ist leer', 'DevEUI ist ungültig']} />
+<ErrorList title='Errors' errors={['AppKey is empty', 'DevEUI is invalid']} />
 <ErrorList errors={['Single error message']} />
 <ErrorList title='Validation Issues' errors={[]} /> {/* Renders nothing */}
 ```
 
 ## Props
 
-| Name   | Type                               | Default  | Description                        |
-| ------ | ---------------------------------- | -------- | ---------------------------------- |
-| errors | string[]                           | []       | Array of error messages to display |
-| title  | string                             | "Fehler" | Title text for the error section   |
-| class  | string                             | -        | Additional CSS classes             |
-| ...    | JSX.HTMLAttributes<HTMLDivElement> | -        | All native div attributes          |
+| Name   | Type                               | Default | Description                                               |
+| ------ | ---------------------------------- | ------- | --------------------------------------------------------- |
+| errors | string[]                           | []      | Array of error messages to display                        |
+| title  | string                             | locale  | Title text; defaults via brand i18n (`Errors` / `Fehler`) |
+| class  | string                             | -       | Additional CSS classes                                    |
+| ...    | JSX.HTMLAttributes\<HTMLDivElement\> | -     | All native div attributes                                 |
 
 ## Design notes
 
 - Automatically hides when errors array is empty (renders null)
 - Uses semantic red color scheme for error indication
-- Includes accessible role="alert" for screen readers  
+- Includes accessible role="alert" for screen readers
 - Features an error icon (X in circle) for immediate visual recognition
 - Error messages displayed as bulleted list for easy scanning
 - Red background with border creates clear visual separation
-- Default title in German ("Fehler") but easily customizable
+- Default title follows the active locale from `LocaleProvider`
 - Consistent spacing and typography with other form components
 - Icon uses currentColor for automatic color inheritance

--- a/web/installer/docs/components/molecules/file-uploader.md
+++ b/web/installer/docs/components/molecules/file-uploader.md
@@ -36,11 +36,11 @@ import { FileUploader } from '@/components/forms/FileUploader';
 
 - Built on FormField component for consistent form styling
 - Uses hidden native file input with custom button interface
-- "Datei auswählen" (SelectField File) button with outline variant styling
+- Select-file button label follows brand i18n (`Select file` / `Datei auswählen`)
 - Shows selected files with names and sizes in KB
-- Includes "Löschen" (Clear) button when files are selected
+- Includes a Clear button when files are selected (localized)
 - File size automatically calculated and displayed with 1 decimal precision
 - Supports both single and multiple file selection
 - Uses unique IDs for accessibility compliance
-- German language interface elements but customizable via props
+- Chrome strings come from `@regenfass/brand` locale dictionaries
 - FormField integration provides unified error and helper text handling

--- a/web/installer/package.json
+++ b/web/installer/package.json
@@ -23,9 +23,10 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@regenfass/brand": "workspace:*",
     "@corvu/otp-field": "^0.1.4",
     "@kobalte/core": "^0.13.11",
+    "@regenfass/brand": "workspace:*",
+    "@solid-primitives/i18n": "^2.2.1",
     "@solidjs/router": "^0.15.3",
     "@tabler/icons-solidjs": "^3.34.1",
     "@xstate/solid": "^2.0.0",
@@ -43,11 +44,11 @@
     "xstate": "^5.21.0"
   },
   "devDependencies": {
-    "@statelyai/inspect": "^0.4.0",
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
     "@playwright/test": "^1.55.0",
     "@solidjs/testing-library": "^0.8.10",
+    "@statelyai/inspect": "^0.4.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@types/crypto-js": "^4.2.2",

--- a/web/installer/src/App.tsx
+++ b/web/installer/src/App.tsx
@@ -1,6 +1,6 @@
 import { Router, Route } from "@solidjs/router";
 import Steps from "./components/molecules/steps/Steps";
-import { Footer, Header, Newsletter } from "@regenfass/brand";
+import { Footer, Header, LocaleProvider, Newsletter } from "@regenfass/brand";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
 
 // Main app layout for the installer
@@ -22,9 +22,11 @@ function App() {
 		<>
 			<ColorModeScript />
 			<ColorModeProvider>
-				<Router>
-					<Route path="/" component={MainApp} />
-				</Router>
+				<LocaleProvider>
+					<Router>
+						<Route path="/" component={MainApp} />
+					</Router>
+				</LocaleProvider>
 			</ColorModeProvider>
 		</>
 	);

--- a/web/installer/src/components/molecules/steps/StepConfigEditing.tsx
+++ b/web/installer/src/components/molecules/steps/StepConfigEditing.tsx
@@ -13,13 +13,13 @@ import {
 import { playErrorSound } from "@/libs/errorSound.ts";
 import { BiRegularClipboard, BiRegularX } from "solid-icons/bi";
 import { For, Show, createSignal, onCleanup } from "solid-js";
-import { Button } from "@regenfass/brand";
-import { AppKeyHexField } from "@regenfass/brand";
-import { TextFieldRoot } from "@regenfass/brand";
 import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	AppKeyHexField,
+	Button,
+	TextFieldRoot,
 } from "@regenfass/brand";
 import {
 	OTPField,
@@ -27,6 +27,7 @@ import {
 	OTPFieldInput,
 	OTPFieldSlot,
 } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -43,6 +44,7 @@ function HexOtp16(props: {
 	onValueChange: (value: string) => void;
 	showCopyButton?: boolean;
 }) {
+	const t = useInstallerT();
 	const [copied, setCopied] = createSignal(false);
 	let copiedTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -64,8 +66,8 @@ function HexOtp16(props: {
 
 	const copyLabel = () =>
 		copied()
-			? `Copied ${props.labelText}`
-			: `Copy ${props.labelText} to clipboard`;
+			? t("configEditing.copied", { label: props.labelText })
+			: t("configEditing.copyToClipboard", { label: props.labelText });
 
 	return (
 		<>
@@ -118,7 +120,9 @@ function HexOtp16(props: {
 						variant="ghost"
 						size="icon"
 						class="h-9 w-9 shrink-0 text-muted-foreground"
-						aria-label={`Clear ${props.labelText}`}
+						aria-label={t("configEditing.clearField", {
+							label: props.labelText,
+						})}
 						onClick={() => props.onValueChange("")}
 					>
 						<BiRegularX aria-hidden={true} size={16} />
@@ -130,6 +134,7 @@ function HexOtp16(props: {
 }
 
 export default function StepConfigEditing({ state, emitEvent }: StepProps) {
+	const t = useInstallerT();
 	const [importError, setImportError] = createSignal<string | null>(null);
 	let fileInputRef: HTMLInputElement | undefined;
 
@@ -156,7 +161,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 			if (error instanceof ConfigFileError) {
 				setImportError(error.message);
 			} else {
-				setImportError("Could not read the configuration file.");
+				setImportError(t("configEditing.couldNotReadFile"));
 			}
 		} finally {
 			input.value = "";
@@ -167,10 +172,10 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 		<div class="rounded-xl border border-border bg-card p-6 shadow-sm ring-1 ring-border/50 dark:ring-border/80">
 			<header class="mb-6 space-y-1.5 border-b border-border pb-5">
 				<h2 class="text-base font-semibold leading-tight tracking-tight text-foreground">
-					Device credentials
+					{t("configEditing.heading")}
 				</h2>
 				<p class="max-w-prose text-sm leading-relaxed text-muted-foreground">
-					These values identify your device on the network. Use hex digits only; the app key stays hidden until you choose to reveal it.
+					{t("configEditing.description")}
 				</p>
 			</header>
 
@@ -178,7 +183,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 				{/* TODO: Autogenerate fields from ConfigV<T> objects */}
 				<TextFieldRoot class="space-y-0">
 					<HexOtp16
-						labelText="appEUI"
+						labelText={t("configEditing.fieldAppEui")}
 						inputId="appEUI-otp"
 						field="appEUI"
 						value={state.context.deviceInfo.config.appEUI}
@@ -195,7 +200,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 
 				<TextFieldRoot class="space-y-0">
 					<HexOtp16
-						labelText="devEUI"
+						labelText={t("configEditing.fieldDevEui")}
 						inputId="devEUI-otp"
 						field="devEUI"
 						value={state.context.deviceInfo.config.devEUI}
@@ -215,7 +220,9 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 						class="block text-sm font-medium leading-none tracking-tight text-foreground"
 						for="appKey-input"
 					>
-						<span class="font-mono text-xs uppercase text-muted-foreground">appKey</span>
+						<span class="font-mono text-xs uppercase text-muted-foreground">
+							{t("configEditing.fieldAppKey")}
+						</span>
 					</label>
 					<div class="mt-2">
 						<AppKeyHexField
@@ -241,7 +248,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 			<Show when={importError()}>
 				{(message) => (
 					<AlertInline variant="destructive" class="mt-6">
-						<AlertTitle>Could not load configuration</AlertTitle>
+						<AlertTitle>{t("configEditing.importErrorTitle")}</AlertTitle>
 						<AlertDescription>{message()}</AlertDescription>
 					</AlertInline>
 				)}
@@ -252,7 +259,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 				type="file"
 				accept=".json,application/json"
 				class="sr-only"
-				aria-label="Load configuration from JSON file"
+				aria-label={t("configEditing.loadFromFileAriaLabel")}
 				onChange={handleFileInputChange}
 			/>
 
@@ -265,7 +272,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 						onClick={() => emitEvent({ type: "config.clear" })}
 					>
 						<IconClearAll aria-hidden={true} size={16} stroke="1.75" />
-						clear
+						{t("configEditing.clear")}
 					</Button>
 					<Button
 						class="gap-1.5"
@@ -274,7 +281,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 						onClick={handleLoadFromFileClick}
 					>
 						<IconFileImport aria-hidden={true} size={16} stroke="1.75" />
-						load from file
+						{t("configEditing.loadFromFile")}
 					</Button>
 					<Button
 						class="gap-1.5"
@@ -283,12 +290,12 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 						onClick={() =>
 							downloadConfigAsJson(
 								state.context.deviceInfo.config,
-								state.context.deviceInfo.configVersion
+								state.context.deviceInfo.configVersion,
 							)
 						}
 					>
 						<IconFileExport aria-hidden={true} size={16} stroke="1.75" />
-						save to file
+						{t("configEditing.saveToFile")}
 					</Button>
 				</div>
 				<Button
@@ -296,7 +303,7 @@ export default function StepConfigEditing({ state, emitEvent }: StepProps) {
 					onClick={() => emitEvent({ type: "config.next" })}
 				>
 					<IconDeviceFloppy aria-hidden={true} size={16} stroke="1.75" />
-					Save to device
+					{t("configEditing.saveToDevice")}
 				</Button>
 			</footer>
 		</div>

--- a/web/installer/src/components/molecules/steps/StepConfigWritingConfiguration.tsx
+++ b/web/installer/src/components/molecules/steps/StepConfigWritingConfiguration.tsx
@@ -3,10 +3,11 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	Progress,
 } from "@regenfass/brand";
-import { Progress } from "@regenfass/brand";
 import { BiSolidMicrochip } from "solid-icons/bi";
 import { createMemo } from "solid-js";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -15,8 +16,10 @@ interface StepProps {
 
 export default function StepConfigWritingConfiguration({
 	state,
-	emitEvent,
+	emitEvent: _emitEvent,
 }: StepProps) {
+	const t = useInstallerT();
+
 	const progressRatio = createMemo(() => {
 		const p = state.context?.configWriteProgress;
 		if (typeof p !== "number" || Number.isNaN(p)) {
@@ -31,19 +34,21 @@ export default function StepConfigWritingConfiguration({
 		<AlertInline>
 			<AlertTitle class="flex items-center gap-2">
 				<Spinner size="lg" />
-				Writing configuration
+				{t("configWritingConfiguration.title")}
 			</AlertTitle>
 			<AlertDescription class="flex flex-col gap-3">
-				<p>
-					Your settings are being sent to the microcontroller over USB—please keep
-					the cable connected until this finishes.
-				</p>
+				<p>{t("configWritingConfiguration.description")}</p>
 				<div class="flex flex-col gap-2">
 					<div class="flex items-center justify-between gap-2 text-sm text-muted-foreground">
-						<span>Upload progress</span>
+						<span>{t("shared.uploadProgress")}</span>
 						<span aria-hidden={true}>{progressPercent()}%</span>
 					</div>
-					<Progress value={progressPercent()} getValueLabel={() => `${progressPercent()} percent`} />
+					<Progress
+						value={progressPercent()}
+						getValueLabel={() =>
+							t("shared.progressPercent", { percent: progressPercent() })
+						}
+					/>
 				</div>
 				<div
 					class="flex items-center gap-2 text-muted-foreground"

--- a/web/installer/src/components/molecules/steps/StepConnectConnecting.tsx
+++ b/web/installer/src/components/molecules/steps/StepConnectConnecting.tsx
@@ -3,17 +3,23 @@ import {
 	AlertInline,
 	AlertTitle,
 } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
 	emitEvent: (event: any) => void;
 }
 
-export default function StepConnectConnecting({ state, emitEvent }: StepProps) {
+export default function StepConnectConnecting({
+	state: _state,
+	emitEvent: _emitEvent,
+}: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<AlertInline>
-			<AlertTitle>Connecting</AlertTitle>
-			<AlertDescription>Trying to connect to your device.</AlertDescription>
+			<AlertTitle>{t("connectConnecting.title")}</AlertTitle>
+			<AlertDescription>{t("connectConnecting.description")}</AlertDescription>
 		</AlertInline>
 	);
 }

--- a/web/installer/src/components/molecules/steps/StepConnectReadingVersion.tsx
+++ b/web/installer/src/components/molecules/steps/StepConnectReadingVersion.tsx
@@ -2,28 +2,36 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	StepPaginator,
 } from "@regenfass/brand";
-import { StepPaginator } from "@regenfass/brand";
-import { INSTALLATION_STEPS } from "@/components/molecules/steps/StepStartWaitingForUser.tsx";
 import { getInstallationActiveStep } from "@/libs/install/installationActiveStep.ts";
+import { useInstallerT } from "@/i18n/index.ts";
+import { installationSteps } from "@/i18n/installationSteps.ts";
 
 interface StepProps {
 	state: any;
 	emitEvent: (event: any) => void;
 }
 
-export default function StepConnectReadingVersion({ state, emitEvent }: StepProps) {
+export default function StepConnectReadingVersion({
+	state,
+	emitEvent: _emitEvent,
+}: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<div class="flex w-full min-w-0 flex-col gap-8">
 			<AlertInline>
-				<AlertTitle>Reading firmware version</AlertTitle>
-				<AlertDescription>Gathering device information.</AlertDescription>
+				<AlertTitle>{t("connectReadingVersion.title")}</AlertTitle>
+				<AlertDescription>
+					{t("connectReadingVersion.description")}
+				</AlertDescription>
 			</AlertInline>
 
 			<StepPaginator
-				title="Installation"
-				steps={INSTALLATION_STEPS}
-				listAriaLabel="Installation steps"
+				title={t("shared.paginatorTitle")}
+				steps={installationSteps(t)}
+				listAriaLabel={t("shared.paginatorListAriaLabel")}
 				activeStep={getInstallationActiveStep(state)}
 			/>
 		</div>

--- a/web/installer/src/components/molecules/steps/StepFinishShowingError.tsx
+++ b/web/installer/src/components/molecules/steps/StepFinishShowingError.tsx
@@ -2,8 +2,9 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	Button,
 } from "@regenfass/brand";
-import { Button } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -11,21 +12,21 @@ interface StepProps {
 }
 
 export default function StepFinishShowingError({ state, emitEvent }: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<div class="space-y-3">
 			<AlertInline variant="destructive">
-				<AlertTitle>Critical error</AlertTitle>
+				<AlertTitle>{t("finishShowingError.title")}</AlertTitle>
 				<AlertDescription>
 					{(state.context.error as unknown as Error).toString()}
 					{(state.context.error as unknown as Error).stack}
-					{JSON.stringify(
-						(state.context.error as unknown as Error).cause!
-					)}
+					{JSON.stringify((state.context.error as unknown as Error).cause!)}
 				</AlertDescription>
 			</AlertInline>
 			<div class="pt-1">
 				<Button onClick={() => emitEvent({ type: "restart" })}>
-					Restart
+					{t("finishShowingError.restart")}
 				</Button>
 			</div>
 		</div>

--- a/web/installer/src/components/molecules/steps/StepFinishShowingNextSteps.tsx
+++ b/web/installer/src/components/molecules/steps/StepFinishShowingNextSteps.tsx
@@ -2,10 +2,11 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	Button,
 } from "@regenfass/brand";
-import { Button } from "@regenfass/brand";
 import { cn } from "@/libs/cn.ts";
 import CircleCheck from "lucide-solid/icons/circle-check";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -17,6 +18,7 @@ export default function StepFinishShowingNextSteps({
 	emitEvent,
 }: StepProps) {
 	void state;
+	const t = useInstallerT();
 
 	return (
 		<div class="space-y-3">
@@ -53,7 +55,7 @@ export default function StepFinishShowingNextSteps({
 								"motion-safe:animate-success-rise motion-safe:[animation-delay:90ms]",
 							)}
 						>
-							Success
+							{t("finishShowingNextSteps.title")}
 						</AlertTitle>
 						<AlertDescription
 							class={cn(
@@ -61,7 +63,7 @@ export default function StepFinishShowingNextSteps({
 								"motion-safe:animate-success-rise motion-safe:[animation-delay:180ms]",
 							)}
 						>
-							All set. You can now use your device.
+							{t("finishShowingNextSteps.body")}
 						</AlertDescription>
 						<AlertDescription
 							class={cn(
@@ -69,8 +71,7 @@ export default function StepFinishShowingNextSteps({
 								"motion-safe:animate-success-rise motion-safe:[animation-delay:270ms]",
 							)}
 						>
-							Setting up another device? You can start a new installation
-							whenever you are ready.
+							{t("finishShowingNextSteps.anotherDevice")}
 						</AlertDescription>
 					</div>
 				</div>
@@ -81,7 +82,7 @@ export default function StepFinishShowingNextSteps({
 					class="w-full sm:w-auto"
 					onClick={() => emitEvent({ type: "restart" })}
 				>
-					Flash another device
+					{t("finishShowingNextSteps.flashAnotherDevice")}
 				</Button>
 			</div>
 		</div>

--- a/web/installer/src/components/molecules/steps/StepInstallInstalling.tsx
+++ b/web/installer/src/components/molecules/steps/StepInstallInstalling.tsx
@@ -3,11 +3,12 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	Progress,
 } from "@regenfass/brand";
-import { Progress } from "@regenfass/brand";
 import { cn } from "@/libs/cn.ts";
 import CircleCheck from "lucide-solid/icons/circle-check";
 import { createMemo, Show } from "solid-js";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -15,6 +16,8 @@ interface StepProps {
 }
 
 export default function StepInstallInstalling(props: StepProps) {
+	const t = useInstallerT();
+
 	const progressRatio = createMemo(() => {
 		const p = props.state.context?.installFlashProgress;
 		if (typeof p !== "number" || Number.isNaN(p)) {
@@ -50,14 +53,15 @@ export default function StepInstallInstalling(props: StepProps) {
 						/>
 					</Show>
 					<span>
-						{isComplete() ? "Installation complete" : "Installing firmware"}
+						{isComplete()
+							? t("installInstalling.titleComplete")
+							: t("installInstalling.titleInProgress")}
 					</span>
 				</AlertTitle>
 				<AlertDescription class="mt-1 flex flex-col gap-4">
 					<Show when={!isComplete()}>
 						<p class="text-muted-foreground">
-							Firmware is being written to the microcontroller over USB—please
-							keep the cable connected until this finishes.
+							{t("installInstalling.descriptionInProgress")}
 						</p>
 					</Show>
 
@@ -70,11 +74,11 @@ export default function StepInstallInstalling(props: StepProps) {
 						role="status"
 						aria-live="polite"
 						aria-busy={!isComplete()}
-						aria-label="Firmware installation progress"
+						aria-label={t("installInstalling.progressAriaLabel")}
 					>
 						<div class="flex items-baseline justify-between gap-3">
 							<span class="text-sm font-medium leading-none text-foreground">
-								Upload progress
+								{t("shared.uploadProgress")}
 							</span>
 							<span
 								class="tabular-nums text-sm font-semibold tracking-tight text-foreground"
@@ -85,7 +89,9 @@ export default function StepInstallInstalling(props: StepProps) {
 						</div>
 						<Progress
 							value={progressPercent()}
-							getValueLabel={() => `${progressPercent()} percent`}
+							getValueLabel={() =>
+								t("shared.progressPercent", { percent: progressPercent() })
+							}
 							class="gap-0"
 						/>
 					</div>
@@ -127,7 +133,7 @@ export default function StepInstallInstalling(props: StepProps) {
 									"motion-safe:animate-success-rise motion-safe:[animation-delay:90ms]",
 								)}
 							>
-								Installation successful
+								{t("installInstalling.successTitle")}
 							</AlertTitle>
 							<AlertDescription
 								class={cn(
@@ -135,11 +141,8 @@ export default function StepInstallInstalling(props: StepProps) {
 									"motion-safe:animate-success-rise motion-safe:[animation-delay:180ms]",
 								)}
 							>
-								<p>The firmware was installed successfully.</p>
-								<p>
-									The next step is configuration. You will be taken there
-									automatically in a moment.
-								</p>
+								<p>{t("installInstalling.successBody")}</p>
+								<p>{t("installInstalling.successNext")}</p>
 							</AlertDescription>
 						</div>
 					</div>

--- a/web/installer/src/components/molecules/steps/StepInstallMigratingConfiguration.tsx
+++ b/web/installer/src/components/molecules/steps/StepInstallMigratingConfiguration.tsx
@@ -3,6 +3,7 @@ import {
 	AlertInline,
 	AlertTitle,
 } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -10,13 +11,17 @@ interface StepProps {
 }
 
 export default function StepInstallMigratingConfiguration({
-	state,
-	emitEvent,
+	state: _state,
+	emitEvent: _emitEvent,
 }: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<AlertInline>
-			<AlertTitle>Migrating configuration</AlertTitle>
-			<AlertDescription>Keeping your settings safe.</AlertDescription>
+			<AlertTitle>{t("installMigratingConfiguration.title")}</AlertTitle>
+			<AlertDescription>
+				{t("installMigratingConfiguration.description")}
+			</AlertDescription>
 		</AlertInline>
 	);
 }

--- a/web/installer/src/components/molecules/steps/StepInstallWaitingForInstallationMethodChoice.tsx
+++ b/web/installer/src/components/molecules/steps/StepInstallWaitingForInstallationMethodChoice.tsx
@@ -2,18 +2,17 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
-} from "@regenfass/brand";
-import { StepPaginator } from "@regenfass/brand";
-import { INSTALLATION_STEPS } from "@/components/molecules/steps/StepStartWaitingForUser.tsx";
-import { getInstallationActiveStep } from "@/libs/install/installationActiveStep.ts";
-import { Button } from "@regenfass/brand";
-import {
+	Button,
 	SelectContent,
 	SelectField,
 	SelectItem,
 	SelectTrigger,
 	SelectValue,
+	StepPaginator,
 } from "@regenfass/brand";
+import { getInstallationActiveStep } from "@/libs/install/installationActiveStep.ts";
+import { useInstallerT } from "@/i18n/index.ts";
+import { installationSteps } from "@/i18n/installationSteps.ts";
 
 interface StepProps {
 	state: any;
@@ -24,19 +23,23 @@ export default function StepInstallWaitingForInstallationMethodChoice({
 	state,
 	emitEvent,
 }: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<div class="space-y-4">
 			<StepPaginator
-				title="Installation"
-				steps={INSTALLATION_STEPS}
-				listAriaLabel="Installation steps"
+				title={t("shared.paginatorTitle")}
+				steps={installationSteps(t)}
+				listAriaLabel={t("shared.paginatorListAriaLabel")}
 				activeStep={getInstallationActiveStep(state)}
 			/>
 
 			<AlertInline>
-				<AlertTitle>Choose installation method</AlertTitle>
+				<AlertTitle>
+					{t("installWaitingForInstallationMethodChoice.alertTitle")}
+				</AlertTitle>
 				<AlertDescription>
-					Install fresh or update existing firmware.
+					{t("installWaitingForInstallationMethodChoice.alertDescription")}
 				</AlertDescription>
 			</AlertInline>
 
@@ -45,20 +48,22 @@ export default function StepInstallWaitingForInstallationMethodChoice({
 					disabled={!state.can({ type: "install.install" })}
 					onClick={() => emitEvent({ type: "install.install" })}
 				>
-					Install
+					{t("installWaitingForInstallationMethodChoice.install")}
 				</Button>
 				<Button
 					disabled={!state.can({ type: "install.configure" })}
 					onClick={() => emitEvent({ type: "install.configure" })}
 				>
-					Configure
+					{t("installWaitingForInstallationMethodChoice.configure")}
 				</Button>
 			</div>
 
 			<SelectField
 				value={state.context.targetFirmwareVersion}
 				options={state.context.upstreamVersions}
-				placeholder="SelectField a version"
+				placeholder={t(
+					"installWaitingForInstallationMethodChoice.versionSelectPlaceholder",
+				)}
 				onChange={(version) =>
 					emitEvent({
 						type: "install.target_version_selected",

--- a/web/installer/src/components/molecules/steps/StepStartCheckingWebSerialSupport.tsx
+++ b/web/installer/src/components/molecules/steps/StepStartCheckingWebSerialSupport.tsx
@@ -3,6 +3,7 @@ import {
 	AlertInline,
 	AlertTitle,
 } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -10,14 +11,16 @@ interface StepProps {
 }
 
 export default function StepStartCheckingWebSerialSupport({
-	state,
-	emitEvent,
+	state: _state,
+	emitEvent: _emitEvent,
 }: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<AlertInline>
-			<AlertTitle>Checking Web Serial support</AlertTitle>
+			<AlertTitle>{t("startCheckingWebSerialSupport.title")}</AlertTitle>
 			<AlertDescription>
-				We are verifying that your browser supports the Web Serial API.
+				{t("startCheckingWebSerialSupport.description")}
 			</AlertDescription>
 		</AlertInline>
 	);

--- a/web/installer/src/components/molecules/steps/StepStartFetchUpstreamVersions.tsx
+++ b/web/installer/src/components/molecules/steps/StepStartFetchUpstreamVersions.tsx
@@ -3,6 +3,7 @@ import {
 	AlertInline,
 	AlertTitle,
 } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
 
 interface StepProps {
 	state: any;
@@ -10,14 +11,16 @@ interface StepProps {
 }
 
 export default function StepStartFetchUpstreamVersions({
-	state,
-	emitEvent,
+	state: _state,
+	emitEvent: _emitEvent,
 }: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<AlertInline>
-			<AlertTitle>Fetching versions</AlertTitle>
+			<AlertTitle>{t("startFetchUpstreamVersions.title")}</AlertTitle>
 			<AlertDescription>
-				Getting the latest available firmware versions.
+				{t("startFetchUpstreamVersions.description")}
 			</AlertDescription>
 		</AlertInline>
 	);

--- a/web/installer/src/components/molecules/steps/StepStartWaitingForUser.tsx
+++ b/web/installer/src/components/molecules/steps/StepStartWaitingForUser.tsx
@@ -2,17 +2,18 @@ import {
 	AlertDescription,
 	AlertInline,
 	AlertTitle,
+	Button,
+	StepPaginator,
 } from "@regenfass/brand";
-import { StepPaginator } from "@regenfass/brand";
 import { getInstallationActiveStep } from "@/libs/install/installationActiveStep.ts";
-import { Button } from "@regenfass/brand";
+import { useInstallerT } from "@/i18n/index.ts";
+import {
+	INSTALLATION_STEPS,
+	installationSteps,
+} from "@/i18n/installationSteps.ts";
 
-/** Labels align with `getInstallationActiveStep`: connect phase → method choice → `Install_Installing`. */
-export const INSTALLATION_STEPS = [
-	"Confirm to start, connect your board over USB, choose the device type, then read the firmware version from the device.",
-	"Pick a firmware version from the list, then choose Install or Configure.",
-	"Wait while the installer flashes firmware to your device.",
-] as const;
+/** @deprecated Prefer `installationSteps(t)` — kept for tests. */
+export { INSTALLATION_STEPS };
 
 interface StepProps {
 	state: any;
@@ -20,40 +21,39 @@ interface StepProps {
 }
 
 export default function StepStartWaitingForUser({ state, emitEvent }: StepProps) {
+	const t = useInstallerT();
+
 	return (
 		<div class="flex w-full min-w-0 flex-col gap-8">
 			<section class="space-y-4">
 				<h1 class="text-3xl font-bold tracking-tight text-foreground md:text-4xl">
-					Hi there! 👋
+					{t("startWaitingForUser.heading")}
 				</h1>
 				<p class="text-lg leading-relaxed text-muted-foreground">
-					This project is about a smart water tank. It measures the
-					water level and sends the data to a server. The server can be
-					used to control the water pump. The pump can be controlled
-					via a web interface or via a telegram bot. It uses an HC-SR04
-					ultrasonic sensor to measure the water level. The data is
-					sent to{" "}
+					{t("startWaitingForUser.introBeforeTtn")}{" "}
 					<span class="bg-gradient-to-br from-primary to-sky-500 bg-clip-text font-medium text-transparent">
-						The Things Network
+						{t("startWaitingForUser.brandTheThingsNetwork")}
 					</span>{" "}
-					via a{" "}
+					{t("startWaitingForUser.introVia")}{" "}
 					<span class="bg-gradient-to-br from-primary to-sky-500 bg-clip-text font-medium text-transparent">
-						LoRaWAN
+						{t("startWaitingForUser.brandLoRaWAN")}
 					</span>{" "}
-					gateway.
+					{t("startWaitingForUser.introAfterLorawan")}
 				</p>
 			</section>
 
 			<AlertInline variant="info">
-				<AlertTitle>Waiting for your confirmation</AlertTitle>
-				<AlertDescription>Please confirm to continue.</AlertDescription>
+				<AlertTitle>{t("startWaitingForUser.alertTitle")}</AlertTitle>
+				<AlertDescription>
+					{t("startWaitingForUser.alertDescription")}
+				</AlertDescription>
 			</AlertInline>
 
 			<div class="space-y-6">
 				<StepPaginator
-					title="Installation"
-					steps={INSTALLATION_STEPS}
-					listAriaLabel="Installation steps"
+					title={t("shared.paginatorTitle")}
+					steps={installationSteps(t)}
+					listAriaLabel={t("shared.paginatorListAriaLabel")}
 					activeStep={getInstallationActiveStep(state)}
 				/>
 
@@ -63,7 +63,7 @@ export default function StepStartWaitingForUser({ state, emitEvent }: StepProps)
 						size="lg"
 						onClick={() => emitEvent({ type: "start.next" })}
 					>
-						Next
+						{t("startWaitingForUser.next")}
 					</Button>
 				</div>
 			</div>

--- a/web/installer/src/i18n/de.ts
+++ b/web/installer/src/i18n/de.ts
@@ -1,0 +1,117 @@
+import type { InstallerDictionary } from "./en.ts";
+
+export const installerDictDe: InstallerDictionary = {
+	installationSteps: {
+		connect:
+			"Bestätige den Start, verbinde dein Board per USB, wähle den Gerätetyp und lies dann die Firmware-Version vom Gerät.",
+		chooseMethod:
+			"Wähle eine Firmware-Version aus der Liste und danach Installieren oder Konfigurieren.",
+		flash: "Warte, während der Installer die Firmware auf dein Gerät schreibt.",
+	},
+	shared: {
+		paginatorTitle: "Installation",
+		paginatorListAriaLabel: "Installationsschritte",
+		uploadProgress: "Upload-Fortschritt",
+		progressPercent: "{{percent}} Prozent",
+	},
+	startCheckingWebSerialSupport: {
+		title: "Web-Serial-Unterstützung wird geprüft",
+		description: "Wir prüfen, ob dein Browser die Web Serial API unterstützt.",
+	},
+	startFetchUpstreamVersions: {
+		title: "Versionen werden geladen",
+		description: "Die neuesten verfügbaren Firmware-Versionen werden abgerufen.",
+	},
+	startWaitingForUser: {
+		heading: "Hi! 👋",
+		introBeforeTtn:
+			"Dieses Projekt dreht sich um einen smarten Wassertank. Er misst den Wasserstand und sendet die Daten an einen Server. Über den Server kann die Wasserpumpe gesteuert werden — per Weboberfläche oder Telegram-Bot. Zur Messung dient ein HC-SR04-Ultraschallsensor. Die Daten gehen an",
+		brandTheThingsNetwork: "The Things Network",
+		introVia: "über ein",
+		brandLoRaWAN: "LoRaWAN",
+		introAfterLorawan: "Gateway.",
+		alertTitle: "Warten auf deine Bestätigung",
+		alertDescription: "Bitte bestätige, um fortzufahren.",
+		next: "Weiter",
+	},
+	connectConnecting: {
+		title: "Verbindung wird hergestellt",
+		description: "Es wird versucht, eine Verbindung zu deinem Gerät herzustellen.",
+	},
+	connectReadingVersion: {
+		title: "Firmware-Version wird gelesen",
+		description: "Geräteinformationen werden erfasst.",
+	},
+	installWaitingForInstallationMethodChoice: {
+		alertTitle: "Installationsmethode wählen",
+		alertDescription: "Frisch installieren oder vorhandene Firmware aktualisieren.",
+		install: "Installieren",
+		configure: "Konfigurieren",
+		versionSelectPlaceholder: "Version auswählen",
+	},
+	installInstalling: {
+		titleInProgress: "Firmware wird installiert",
+		titleComplete: "Installation abgeschlossen",
+		descriptionInProgress:
+			"Die Firmware wird über USB auf den Mikrocontroller geschrieben — bitte lass das Kabel verbunden, bis der Vorgang fertig ist.",
+		progressAriaLabel: "Fortschritt der Firmware-Installation",
+		successTitle: "Installation erfolgreich",
+		successBody: "Die Firmware wurde erfolgreich installiert.",
+		successNext:
+			"Als Nächstes folgt die Konfiguration. Du wirst gleich automatisch weitergeleitet.",
+	},
+	installMigratingConfiguration: {
+		title: "Konfiguration wird migriert",
+		description: "Deine Einstellungen bleiben erhalten.",
+	},
+	configEditing: {
+		heading: "Geräte-Zugangsdaten",
+		description:
+			"Diese Werte identifizieren dein Gerät im Netzwerk. Nur Hex-Ziffern verwenden; der App-Key bleibt verborgen, bis du ihn anzeigst.",
+		fieldAppEui: "appEUI",
+		fieldDevEui: "devEUI",
+		fieldAppKey: "appKey",
+		copyToClipboard: "{{label}} in die Zwischenablage kopieren",
+		copied: "{{label}} kopiert",
+		clearField: "{{label}} löschen",
+		importErrorTitle: "Konfiguration konnte nicht geladen werden",
+		couldNotReadFile: "Die Konfigurationsdatei konnte nicht gelesen werden.",
+		loadFromFileAriaLabel: "Konfiguration aus JSON-Datei laden",
+		clear: "löschen",
+		loadFromFile: "aus Datei laden",
+		saveToFile: "in Datei speichern",
+		saveToDevice: "Auf Gerät speichern",
+	},
+	configWritingConfiguration: {
+		title: "Konfiguration wird geschrieben",
+		description:
+			"Deine Einstellungen werden über USB an den Mikrocontroller gesendet — bitte lass das Kabel verbunden, bis der Vorgang fertig ist.",
+	},
+	finishShowingNextSteps: {
+		title: "Erfolg",
+		body: "Alles erledigt. Du kannst dein Gerät jetzt nutzen.",
+		anotherDevice:
+			"Noch ein Gerät einrichten? Du kannst jederzeit eine neue Installation starten.",
+		flashAnotherDevice: "Weiteres Gerät flashen",
+	},
+	finishShowingError: {
+		title: "Kritischer Fehler",
+		restart: "Neu starten",
+	},
+	stateErrors: {
+		unsupportedBrowser: "Nicht unterstützter Browser",
+		unknownConfigVersion:
+			"Unbekannte Konfigurationsversion: {{configVersion}}, es ist kein Loader implementiert",
+		migrateFailed:
+			"Migration von {{fromVersion}} nach {{toVersion}} (Ziel {{desiredVersion}}) fehlgeschlagen: kein Handler für Konfigurationsformat v{{toVersion}} gefunden",
+	},
+	configFileErrors: {
+		invalidJson: "Ungültiges JSON-Format",
+		missingOrInvalidField: "Fehlendes oder ungültiges Feld {{field}}",
+		appEuiLength: "appEUI muss 16 Hex-Ziffern haben",
+		devEuiLength: "devEUI muss 16 Hex-Ziffern haben",
+		appKeyLength: "appKey muss 32 Hex-Ziffern haben",
+		configVersionMustBeNumber: "configVersion muss eine Zahl sein",
+		unsupportedConfigVersion: "Nicht unterstützte Konfigurationsversion: {{version}}",
+	},
+};

--- a/web/installer/src/i18n/en.ts
+++ b/web/installer/src/i18n/en.ts
@@ -1,4 +1,85 @@
-export const installerDictEn = {
+export type InstallerDictionary = {
+	installationSteps: { connect: string; chooseMethod: string; flash: string };
+	shared: {
+		paginatorTitle: string;
+		paginatorListAriaLabel: string;
+		uploadProgress: string;
+		progressPercent: string;
+	};
+	startCheckingWebSerialSupport: { title: string; description: string };
+	startFetchUpstreamVersions: { title: string; description: string };
+	startWaitingForUser: {
+		heading: string;
+		introBeforeTtn: string;
+		brandTheThingsNetwork: string;
+		introVia: string;
+		brandLoRaWAN: string;
+		introAfterLorawan: string;
+		alertTitle: string;
+		alertDescription: string;
+		next: string;
+	};
+	connectConnecting: { title: string; description: string };
+	connectReadingVersion: { title: string; description: string };
+	installWaitingForInstallationMethodChoice: {
+		alertTitle: string;
+		alertDescription: string;
+		install: string;
+		configure: string;
+		versionSelectPlaceholder: string;
+	};
+	installInstalling: {
+		titleInProgress: string;
+		titleComplete: string;
+		descriptionInProgress: string;
+		progressAriaLabel: string;
+		successTitle: string;
+		successBody: string;
+		successNext: string;
+	};
+	installMigratingConfiguration: { title: string; description: string };
+	configEditing: {
+		heading: string;
+		description: string;
+		fieldAppEui: string;
+		fieldDevEui: string;
+		fieldAppKey: string;
+		copyToClipboard: string;
+		copied: string;
+		clearField: string;
+		importErrorTitle: string;
+		couldNotReadFile: string;
+		loadFromFileAriaLabel: string;
+		clear: string;
+		loadFromFile: string;
+		saveToFile: string;
+		saveToDevice: string;
+	};
+	configWritingConfiguration: { title: string; description: string };
+	finishShowingNextSteps: {
+		title: string;
+		body: string;
+		anotherDevice: string;
+		flashAnotherDevice: string;
+	};
+	finishShowingError: { title: string; restart: string };
+	stateErrors: {
+		unsupportedBrowser: string;
+		unknownConfigVersion: string;
+		migrateFailed: string;
+	};
+	configFileErrors: {
+		invalidJson: string;
+		missingOrInvalidField: string;
+		appEuiLength: string;
+		devEuiLength: string;
+		appKeyLength: string;
+		configVersionMustBeNumber: string;
+		unsupportedConfigVersion: string;
+	};
+};
+
+export const installerDictEn: InstallerDictionary = {
 	installationSteps: {
 		connect:
 			"Confirm to start, connect your board over USB, choose the device type, then read the firmware version from the device.",
@@ -113,6 +194,4 @@ export const installerDictEn = {
 		configVersionMustBeNumber: "configVersion must be a number",
 		unsupportedConfigVersion: "Unsupported config version: {{version}}",
 	},
-} as const;
-
-export type InstallerDictionary = typeof installerDictEn;
+};

--- a/web/installer/src/i18n/en.ts
+++ b/web/installer/src/i18n/en.ts
@@ -1,0 +1,118 @@
+export const installerDictEn = {
+	installationSteps: {
+		connect:
+			"Confirm to start, connect your board over USB, choose the device type, then read the firmware version from the device.",
+		chooseMethod:
+			"Pick a firmware version from the list, then choose Install or Configure.",
+		flash: "Wait while the installer flashes firmware to your device.",
+	},
+	shared: {
+		paginatorTitle: "Installation",
+		paginatorListAriaLabel: "Installation steps",
+		uploadProgress: "Upload progress",
+		progressPercent: "{{percent}} percent",
+	},
+	startCheckingWebSerialSupport: {
+		title: "Checking Web Serial support",
+		description:
+			"We are verifying that your browser supports the Web Serial API.",
+	},
+	startFetchUpstreamVersions: {
+		title: "Fetching versions",
+		description: "Getting the latest available firmware versions.",
+	},
+	startWaitingForUser: {
+		heading: "Hi there! 👋",
+		introBeforeTtn:
+			"This project is about a smart water tank. It measures the water level and sends the data to a server. The server can be used to control the water pump. The pump can be controlled via a web interface or via a telegram bot. It uses an HC-SR04 ultrasonic sensor to measure the water level. The data is sent to",
+		brandTheThingsNetwork: "The Things Network",
+		introVia: "via a",
+		brandLoRaWAN: "LoRaWAN",
+		introAfterLorawan: "gateway.",
+		alertTitle: "Waiting for your confirmation",
+		alertDescription: "Please confirm to continue.",
+		next: "Next",
+	},
+	connectConnecting: {
+		title: "Connecting",
+		description: "Trying to connect to your device.",
+	},
+	connectReadingVersion: {
+		title: "Reading firmware version",
+		description: "Gathering device information.",
+	},
+	installWaitingForInstallationMethodChoice: {
+		alertTitle: "Choose installation method",
+		alertDescription: "Install fresh or update existing firmware.",
+		install: "Install",
+		configure: "Configure",
+		versionSelectPlaceholder: "Select a version",
+	},
+	installInstalling: {
+		titleInProgress: "Installing firmware",
+		titleComplete: "Installation complete",
+		descriptionInProgress:
+			"Firmware is being written to the microcontroller over USB—please keep the cable connected until this finishes.",
+		progressAriaLabel: "Firmware installation progress",
+		successTitle: "Installation successful",
+		successBody: "The firmware was installed successfully.",
+		successNext:
+			"The next step is configuration. You will be taken there automatically in a moment.",
+	},
+	installMigratingConfiguration: {
+		title: "Migrating configuration",
+		description: "Keeping your settings safe.",
+	},
+	configEditing: {
+		heading: "Device credentials",
+		description:
+			"These values identify your device on the network. Use hex digits only; the app key stays hidden until you choose to reveal it.",
+		fieldAppEui: "appEUI",
+		fieldDevEui: "devEUI",
+		fieldAppKey: "appKey",
+		copyToClipboard: "Copy {{label}} to clipboard",
+		copied: "Copied {{label}}",
+		clearField: "Clear {{label}}",
+		importErrorTitle: "Could not load configuration",
+		couldNotReadFile: "Could not read the configuration file.",
+		loadFromFileAriaLabel: "Load configuration from JSON file",
+		clear: "clear",
+		loadFromFile: "load from file",
+		saveToFile: "save to file",
+		saveToDevice: "Save to device",
+	},
+	configWritingConfiguration: {
+		title: "Writing configuration",
+		description:
+			"Your settings are being sent to the microcontroller over USB—please keep the cable connected until this finishes.",
+	},
+	finishShowingNextSteps: {
+		title: "Success",
+		body: "All set. You can now use your device.",
+		anotherDevice:
+			"Setting up another device? You can start a new installation whenever you are ready.",
+		flashAnotherDevice: "Flash another device",
+	},
+	finishShowingError: {
+		title: "Critical error",
+		restart: "Restart",
+	},
+	stateErrors: {
+		unsupportedBrowser: "Unsupported browser",
+		unknownConfigVersion:
+			"Unknown config version: {{configVersion}}, there is no loader implemented",
+		migrateFailed:
+			"Failed to migrate from {{fromVersion}} to {{toVersion}} (to get to {{desiredVersion}}), could not find handler for config format for v{{toVersion}}",
+	},
+	configFileErrors: {
+		invalidJson: "Invalid JSON format",
+		missingOrInvalidField: "Missing or invalid {{field}}",
+		appEuiLength: "appEUI must be 16 hex digits",
+		devEuiLength: "devEUI must be 16 hex digits",
+		appKeyLength: "appKey must be 32 hex digits",
+		configVersionMustBeNumber: "configVersion must be a number",
+		unsupportedConfigVersion: "Unsupported config version: {{version}}",
+	},
+} as const;
+
+export type InstallerDictionary = typeof installerDictEn;

--- a/web/installer/src/i18n/index.ts
+++ b/web/installer/src/i18n/index.ts
@@ -1,0 +1,48 @@
+import { createMemo } from "solid-js";
+import {
+	flatten,
+	resolveTemplate,
+	translator,
+	type Flatten,
+	type Translator,
+} from "@solid-primitives/i18n";
+import {
+	resolveLocale,
+	useLocaleOptional,
+	type Locale,
+} from "@regenfass/brand";
+import { installerDictDe } from "./de.ts";
+import { installerDictEn, type InstallerDictionary } from "./en.ts";
+
+export type { InstallerDictionary };
+export { installerDictDe, installerDictEn };
+
+export const installerDictionaries: Record<Locale, InstallerDictionary> = {
+	de: installerDictDe,
+	en: installerDictEn,
+};
+
+export type FlatInstallerDictionary = Flatten<InstallerDictionary>;
+
+/** Falls back to resolveLocale() outside LocaleProvider (tests / early boot). */
+export function useInstallerT(): Translator<FlatInstallerDictionary> {
+	const ctx = useLocaleOptional();
+	const dict = createMemo(() =>
+		flatten(installerDictionaries[ctx?.locale() ?? resolveLocale()]),
+	);
+	return translator(dict, resolveTemplate);
+}
+
+/** Non-reactive messages for thrown errors (reads cookie/browser locale). */
+export function installerMessage(
+	path: keyof FlatInstallerDictionary,
+	args?: Record<string, string | number | boolean>,
+): string {
+	const flat = flatten(installerDictionaries[resolveLocale()]);
+	const value = flat[path];
+	if (typeof value !== "string") {
+		return String(value ?? path);
+	}
+	if (!args) return value;
+	return resolveTemplate(value, args);
+}

--- a/web/installer/src/i18n/installationSteps.ts
+++ b/web/installer/src/i18n/installationSteps.ts
@@ -1,0 +1,21 @@
+import type { Translator } from "@solid-primitives/i18n";
+import { installerDictEn } from "./en.ts";
+import type { FlatInstallerDictionary } from "./index.ts";
+
+/** Labels align with `getInstallationActiveStep`: connect → method choice → flash. */
+export function installationSteps(
+	t: Translator<FlatInstallerDictionary>,
+): string[] {
+	return [
+		t("installationSteps.connect"),
+		t("installationSteps.chooseMethod"),
+		t("installationSteps.flash"),
+	];
+}
+
+/** English step labels for tests that assert paginator copy. */
+export const INSTALLATION_STEPS = [
+	installerDictEn.installationSteps.connect,
+	installerDictEn.installationSteps.chooseMethod,
+	installerDictEn.installationSteps.flash,
+] as const;

--- a/web/installer/src/libs/downloadConfig.ts
+++ b/web/installer/src/libs/downloadConfig.ts
@@ -3,6 +3,7 @@ import {
 	type Config,
 } from "@/libs/install/config.ts";
 import { normalizeAppKeyHexInput } from "@/libs/hexKeyDisplay.ts";
+import { installerMessage } from "@/i18n/index.ts";
 
 export type ConfigExportPayload = Config & {
 	configVersion?: number;
@@ -26,7 +27,9 @@ function requireStringField(
 ): string {
 	const value = data[field];
 	if (typeof value !== "string") {
-		throw new ConfigFileError(`Missing or invalid ${field}`);
+		throw new ConfigFileError(
+			installerMessage("configFileErrors.missingOrInvalidField", { field }),
+		);
 	}
 	return value;
 }
@@ -40,11 +43,11 @@ export function parseConfigFileContent(text: string): {
 	try {
 		parsed = JSON.parse(text);
 	} catch {
-		throw new ConfigFileError("Invalid JSON format");
+		throw new ConfigFileError(installerMessage("configFileErrors.invalidJson"));
 	}
 
 	if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-		throw new ConfigFileError("Invalid JSON format");
+		throw new ConfigFileError(installerMessage("configFileErrors.invalidJson"));
 	}
 
 	const data = parsed as Record<string, unknown>;
@@ -54,26 +57,30 @@ export function parseConfigFileContent(text: string): {
 	const appKey = normalizeAppKeyHexInput(requireStringField(data, "appKey")).toUpperCase();
 
 	if (appEUI.length !== 16) {
-		throw new ConfigFileError("appEUI must be 16 hex digits");
+		throw new ConfigFileError(installerMessage("configFileErrors.appEuiLength"));
 	}
 	if (devEUI.length !== 16) {
-		throw new ConfigFileError("devEUI must be 16 hex digits");
+		throw new ConfigFileError(installerMessage("configFileErrors.devEuiLength"));
 	}
 	if (appKey.length !== 32) {
-		throw new ConfigFileError("appKey must be 32 hex digits");
+		throw new ConfigFileError(installerMessage("configFileErrors.appKeyLength"));
 	}
 
 	let configVersion: number | undefined;
 	if ("configVersion" in data && data.configVersion != null) {
 		if (typeof data.configVersion !== "number") {
-			throw new ConfigFileError("configVersion must be a number");
+			throw new ConfigFileError(
+				installerMessage("configFileErrors.configVersionMustBeNumber"),
+			);
 		}
 		const supported = CONFIG_VERSIONS.some(
 			(version) => version.version === data.configVersion
 		);
 		if (!supported) {
 			throw new ConfigFileError(
-				`Unsupported config version: ${data.configVersion}`
+				installerMessage("configFileErrors.unsupportedConfigVersion", {
+					version: data.configVersion as number,
+				}),
 			);
 		}
 		configVersion = data.configVersion;

--- a/web/installer/src/libs/install/installationActiveStep.ts
+++ b/web/installer/src/libs/install/installationActiveStep.ts
@@ -1,7 +1,7 @@
 /**
  * Maps the setup wizard’s XState node to the 1-based `activeStep` used by
- * `StepPaginator`, aligned with `INSTALLATION_STEPS` in
- * `StepStartWaitingForUser.tsx`:
+ * `StepPaginator`, aligned with `installationSteps` / `INSTALLATION_STEPS`
+ * in `src/i18n/installationSteps.ts`:
  *
  * - **1** — Connect & identify: `Start_WaitingForUser`, `Connect_Connecting`, `Connect_ReadingVersion`
  * - **2** — Version + method: `Install_WaitingForInstallationMethodChoice`

--- a/web/installer/src/libs/install/state.ts
+++ b/web/installer/src/libs/install/state.ts
@@ -12,6 +12,7 @@ import { ESPLoader, LoaderOptions, Transport } from "esptool-js";
 import JSZip from "jszip";
 import { playErrorSound } from "@/libs/errorSound.ts";
 import { startModemSound, stopModemSound } from "@/libs/modemSound.ts";
+import { installerMessage } from "@/i18n/index.ts";
 import { assign, fromCallback, fromPromise, setup } from "xstate";
 
 const url =
@@ -48,7 +49,9 @@ const loadDeviceInfo = async (connection: SCPAdapter): Promise<DeviceInfo> => {
 	);
 	if (!applicableConfig) {
 		throw new Error(
-			`Unknown config version: ${configVersion}, there is no loader implemented`
+			installerMessage("stateErrors.unknownConfigVersion", {
+				configVersion,
+			}),
 		);
 	}
 
@@ -97,7 +100,11 @@ const migrateConfiguration = async (
 		);
 		if (!nextConfigVersion) {
 			throw new Error(
-				`Failed to migrate from ${info.configVersion} to ${nextVersion} (to get to ${desiredVersion}), could not find handler for config format for v${nextVersion}`
+				installerMessage("stateErrors.migrateFailed", {
+					fromVersion: info.configVersion,
+					toVersion: nextVersion,
+					desiredVersion,
+				}),
 			);
 		}
 
@@ -410,7 +417,8 @@ export const setupStateMachine = setup({
 						target: "Finish_ShowingError",
 						guard: "webSerialNotSupported",
 						actions: assign({
-							error: () => "Unsupported browser",
+							error: () =>
+								installerMessage("stateErrors.unsupportedBrowser"),
 						}),
 					},
 				],

--- a/web/installer/tests/components/forms/FileUploader.test.tsx
+++ b/web/installer/tests/components/forms/FileUploader.test.tsx
@@ -43,7 +43,7 @@ describe("FileUploader", () => {
 
 	it("renders select button", () => {
 		render(() => <FileUploader label="Upload File" />);
-		expect(screen.getByText("Datei auswählen")).toBeInTheDocument();
+		expect(screen.getByText("Select file")).toBeInTheDocument();
 	});
 
 	it("calls onFileSelect when file is selected", () => {
@@ -90,7 +90,7 @@ describe("FileUploader", () => {
 		});
 
 		fireEvent.change(input);
-		expect(screen.getByText("Ausgewählte Dateien:")).toBeInTheDocument();
+		expect(screen.getByText("Selected files:")).toBeInTheDocument();
 		expect(screen.getByText(/test\.txt/)).toBeInTheDocument();
 	});
 
@@ -114,7 +114,7 @@ describe("FileUploader", () => {
 		});
 
 		fireEvent.change(input);
-		expect(screen.getByText("Löschen")).toBeInTheDocument();
+		expect(screen.getByText("Clear")).toBeInTheDocument();
 	});
 
 	it("clears files when delete button is clicked", () => {
@@ -138,7 +138,7 @@ describe("FileUploader", () => {
 		});
 
 		fireEvent.change(input);
-		const deleteButton = screen.getByText("Löschen");
+		const deleteButton = screen.getByText("Clear");
 		fireEvent.click(deleteButton);
 		expect(handleFileSelect).toHaveBeenCalledWith(null);
 	});

--- a/web/installer/tests/components/molecules/ErrorList.test.tsx
+++ b/web/installer/tests/components/molecules/ErrorList.test.tsx
@@ -34,13 +34,13 @@ describe("ErrorList", () => {
 
   it("renders with default title", () => {
     render(() => <ErrorList errors={["Error"]} />);
-    expect(screen.getByText("Fehler")).toBeInTheDocument();
+    expect(screen.getByText("Errors")).toBeInTheDocument();
   });
 
   it("renders with custom title", () => {
     render(() => <ErrorList errors={["Error"]} title="Custom Title" />);
     expect(screen.getByText("Custom Title")).toBeInTheDocument();
-    expect(screen.queryByText("Fehler")).not.toBeInTheDocument();
+    expect(screen.queryByText("Errors")).not.toBeInTheDocument();
   });
 
   it("has correct role attribute", () => {

--- a/web/installer/tests/i18n/localeSmoke.test.tsx
+++ b/web/installer/tests/i18n/localeSmoke.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { LocaleProvider, useLocale } from "@regenfass/brand";
+import StepStartWaitingForUser from "@/components/molecules/steps/StepStartWaitingForUser.tsx";
+import { installerDictDe } from "@/i18n/de.ts";
+
+function LocaleProbe() {
+	const { locale, setLocale } = useLocale();
+	return (
+		<div>
+			<span data-testid="locale">{locale()}</span>
+			<button type="button" onClick={() => setLocale("de")}>
+				to-de
+			</button>
+			<button type="button" onClick={() => setLocale("en")}>
+				to-en
+			</button>
+		</div>
+	);
+}
+
+describe("installer locale smoke", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("renders German welcome copy after setLocale(de)", async () => {
+		const mockState = {
+			matches: (id: string) => id === "Start_WaitingForUser",
+		};
+
+		render(() => (
+			<LocaleProvider initialLocale="en">
+				<StepStartWaitingForUser state={mockState} emitEvent={() => {}} />
+				<LocaleProbe />
+			</LocaleProvider>
+		));
+
+		expect(screen.getByText("Waiting for your confirmation")).toBeInTheDocument();
+
+		screen.getByRole("button", { name: "to-de" }).click();
+
+		expect(
+			await screen.findByText(installerDictDe.startWaitingForUser.alertTitle),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("locale")).toHaveTextContent("de");
+	});
+});

--- a/web/installer/tests/i18n/marketingLocaleRouting.test.ts
+++ b/web/installer/tests/i18n/marketingLocaleRouting.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	localeRedirectPath,
 	parseLocaleParam,
-} from "../../../../marketing/src/i18n/localeRouting.ts";
+} from "../../../marketing/src/i18n/localeRouting.ts";
 import { LOCALE_COOKIE_NAME } from "@regenfass/brand";
 
 describe("marketing locale routing helpers", () => {

--- a/web/installer/tests/i18n/marketingLocaleRouting.test.ts
+++ b/web/installer/tests/i18n/marketingLocaleRouting.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+	localeRedirectPath,
+	parseLocaleParam,
+} from "../../../../marketing/src/i18n/localeRouting.ts";
+import { LOCALE_COOKIE_NAME } from "@regenfass/brand";
+
+describe("marketing locale routing helpers", () => {
+	it("redirects / to cookie locale and preserves hash", () => {
+		expect(
+			localeRedirectPath(`${LOCALE_COOKIE_NAME}=de`, ["en-US"], "#changelog"),
+		).toBe("/de#changelog");
+		expect(localeRedirectPath("", ["en-GB"], "")).toBe("/en");
+	});
+
+	it("accepts only de|en path segments", () => {
+		expect(parseLocaleParam("de")).toBe("de");
+		expect(parseLocaleParam("en")).toBe("en");
+		expect(parseLocaleParam("fr")).toBeNull();
+		expect(parseLocaleParam(undefined)).toBeNull();
+	});
+});

--- a/web/installer/tests/libs/localePreference.test.ts
+++ b/web/installer/tests/libs/localePreference.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	cookieDomainForHost,
+	detectBrowserLocale,
+	parseLocaleFromCookieString,
+	resetLocalePreferenceForTests,
+	resolveLocale,
+	writeLocaleCookie,
+	readLocaleCookie,
+	LOCALE_COOKIE_NAME,
+} from "@regenfass/brand";
+
+describe("locale preference", () => {
+	afterEach(() => {
+		resetLocalePreferenceForTests();
+	});
+
+	it("cookieDomainForHost uses .regenfass.eu for production hosts", () => {
+		expect(cookieDomainForHost("regenfass.eu")).toBe(".regenfass.eu");
+		expect(cookieDomainForHost("install.regenfass.eu")).toBe(".regenfass.eu");
+		expect(cookieDomainForHost("localhost")).toBeUndefined();
+		expect(cookieDomainForHost("regenfass-marketing.netlify.app")).toBeUndefined();
+	});
+
+	it("detectBrowserLocale prefers German tags", () => {
+		expect(detectBrowserLocale(["de-DE", "en-US"])).toBe("de");
+		expect(detectBrowserLocale(["en-GB"])).toBe("en");
+		expect(detectBrowserLocale(["fr-FR"])).toBe("en");
+	});
+
+	it("parseLocaleFromCookieString reads regenfass-locale", () => {
+		expect(
+			parseLocaleFromCookieString(`${LOCALE_COOKIE_NAME}=de; other=1`),
+		).toBe("de");
+		expect(parseLocaleFromCookieString("other=1")).toBeNull();
+		expect(parseLocaleFromCookieString(`${LOCALE_COOKIE_NAME}=fr`)).toBeNull();
+	});
+
+	it("resolveLocale prefers cookie over browser languages", () => {
+		expect(resolveLocale(`${LOCALE_COOKIE_NAME}=de`, ["en-US"])).toBe("de");
+		expect(resolveLocale("", ["de-DE"])).toBe("de");
+		expect(resolveLocale("", ["en-US"])).toBe("en");
+	});
+
+	it("writeLocaleCookie persists override readable via readLocaleCookie", () => {
+		writeLocaleCookie("de");
+		expect(readLocaleCookie()).toBe("de");
+		expect(resolveLocale()).toBe("de");
+	});
+});

--- a/web/marketing/index.html
+++ b/web/marketing/index.html
@@ -8,7 +8,10 @@
       name="description"
       content="Regenfass measures water level in rain barrels and tanks, and sends readings over LoRaWAN via The Things Network. Open source IoT by TTN Leipzig."
     />
-    <link rel="canonical" href="https://regenfass.eu/" />
+    <link rel="canonical" href="https://regenfass.eu/en" />
+    <link rel="alternate" hreflang="en" href="https://regenfass.eu/en" />
+    <link rel="alternate" hreflang="de" href="https://regenfass.eu/de" />
+    <link rel="alternate" hreflang="x-default" href="https://regenfass.eu/en" />
   </head>
   <body
     class="min-h-screen min-h-dvh bg-fixed text-slate-700 dark:text-slate-100 bg-slate-100 dark:bg-slate-900"

--- a/web/marketing/package.json
+++ b/web/marketing/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@kobalte/core": "^0.13.11",
     "@regenfass/brand": "workspace:*",
+    "@solid-primitives/i18n": "^2.2.1",
     "@solidjs/router": "^0.15.3",
     "marked": "^15.0.12",
     "solid-js": "^1.9.9"

--- a/web/marketing/src/App.tsx
+++ b/web/marketing/src/App.tsx
@@ -1,313 +1,322 @@
-import { For, type ParentProps } from "solid-js";
-import { Router, Route } from "@solidjs/router";
+import { For, Show, createEffect, type ParentProps } from "solid-js";
 import {
-  Badge,
-  ButtonPrimary,
-  ButtonSecondary,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Footer,
-  Header,
-  Headline,
-  Link,
-  Newsletter,
-  trackEvent,
-  type HeaderNavItem,
+	Navigate,
+	Route,
+	Router,
+	useNavigate,
+	useParams,
+	type RouteSectionProps,
+} from "@solidjs/router";
+import {
+	Badge,
+	ButtonPrimary,
+	ButtonSecondary,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Footer,
+	Header,
+	Headline,
+	isLocale,
+	Link,
+	LocaleProvider,
+	Newsletter,
+	resolveLocale,
+	trackEvent,
+	useLocale,
+	type HeaderNavItem,
+	type Locale,
 } from "@regenfass/brand";
 import ChangelogSection from "./ChangelogSection";
+import { marketingCopy, useMarketingT } from "./i18n/index.ts";
+import { localeRedirectPath } from "./i18n/localeRouting.ts";
+import { applyMarketingSeo } from "./i18n/seo.ts";
 
 const DOCS_URL = "https://docs.regenfass.eu/";
 const INSTALLER_URL = "https://install.regenfass.eu";
 
 function trackNavigateToDocs() {
-  trackEvent("navigate_to_docs");
+	trackEvent("navigate_to_docs");
 }
 
 function trackNavigateToInstaller() {
-  trackEvent("navigate_to_installer");
+	trackEvent("navigate_to_installer");
 }
 
-const NAV: HeaderNavItem[] = [
-  { href: "/", label: "Home" },
-  { href: "/#changelog", label: "Changelog" },
-  {
-    href: DOCS_URL,
-    label: "Docs",
-    external: true,
-    onClick: trackNavigateToDocs,
-  },
-  {
-    href: INSTALLER_URL,
-    label: "Installer",
-    external: true,
-    onClick: trackNavigateToInstaller,
-  },
-  { href: "https://brand.regenfass.eu", label: "Brand", external: true },
-  {
-    href: "https://github.com/ttnleipzig/regenfass",
-    label: "GitHub",
-    external: true,
-  },
-];
+function LocaleRedirect() {
+	const hash = typeof location !== "undefined" ? location.hash : "";
+	return <Navigate href={localeRedirectPath(undefined, undefined, hash)} />;
+}
 
-const WHY = [
-  {
-    title: "Home rain barrels",
-    body: "Know how much water is left after a dry spell—before the next watering session.",
-  },
-  {
-    title: "Community gardens",
-    body: "Share a clear fill level with gardeners so everyone can water fairly and sparingly.",
-  },
-  {
-    title: "Larger tanks",
-    body: "Monitor cisterns and storage tanks without climbing lids or guessing from a dip stick.",
-  },
-];
+function InvalidLocaleRedirect() {
+	return <Navigate href={localeRedirectPath()} />;
+}
 
-const STEPS = [
-  { step: "1", title: "Sense", body: "An ultrasonic or ToF sensor reads distance to the water surface." },
-  { step: "2", title: "Compute", body: "An ESP32 board converts distance into fill level on device." },
-  { step: "3", title: "Transmit", body: "LoRaWAN sends small payloads over long range with low power." },
-  { step: "4", title: "Network", body: "The Things Network routes messages to apps you choose." },
-  { step: "5", title: "Dashboard", body: "View trends in Grafana, Node-RED, or any MQTT-ready tool." },
-];
+function Shell(props: ParentProps & { lang: Locale }) {
+	const t = useMarketingT();
+	const base = `/${props.lang}`;
 
-const HARDWARE = [
-  {
-    title: "Heltec WiFi LoRa 32",
-    body: "ESP32 with onboard LoRa radio—flash and configure from the browser.",
-    src: "/img/hardware-esplora.svg",
-  },
-  {
-    title: "HC-SR04 (and friends)",
-    body: "Affordable ultrasonic sensing for prototypes; waterproof options for longer installs.",
-    src: "/img/sensor-hcsr04.svg",
-  },
-  {
-    title: "Power & housing",
-    body: "Optional OLED display, 18650 cells, and a weather-minded enclosure for outdoor use.",
-    src: "/img/hardware-18650.svg",
-  },
-];
+	const navItems = (): HeaderNavItem[] => [
+		{ href: base, label: t("nav.home") },
+		{ href: `${base}#changelog`, label: t("nav.changelog") },
+		{
+			href: DOCS_URL,
+			label: t("nav.docs"),
+			external: true,
+			onClick: trackNavigateToDocs,
+		},
+		{
+			href: INSTALLER_URL,
+			label: t("nav.installer"),
+			external: true,
+			onClick: trackNavigateToInstaller,
+		},
+		{
+			href: "https://brand.regenfass.eu",
+			label: t("nav.brand"),
+			external: true,
+		},
+		{
+			href: "https://github.com/ttnleipzig/regenfass",
+			label: t("nav.github"),
+			external: true,
+		},
+	];
 
-const CASES = [
-  {
-    title: "Garden watering decisions",
-    body: "Skip the guesswork: open a chart and decide whether to irrigate today.",
-  },
-  {
-    title: "Seasonal dryness alerts",
-    body: "Catch empty or near-empty tanks early during heatwaves and dry weeks.",
-  },
-  {
-    title: "Shared site visibility",
-    body: "Give allotment or school garden groups one shared reading source.",
-  },
-];
-
-function Shell(props: ParentProps) {
-  return (
-    <div class="min-h-screen flex flex-col">
-      <Header title="Regenfass" navItems={NAV} />
-      <main class="flex-1">{props.children}</main>
-      <Footer />
-    </div>
-  );
+	return (
+		<div class="min-h-screen flex flex-col">
+			<Header title="Regenfass" navItems={navItems()} />
+			<main class="flex-1">{props.children}</main>
+			<Footer />
+		</div>
+	);
 }
 
 function Home() {
-  return (
-    <Shell>
-      {/* 1. Hero — brand first, no cards */}
-      <section class="relative overflow-hidden hero-glow">
-        <div class="absolute inset-0 grid-quiet pointer-events-none" aria-hidden="true" />
-        <div class="site-container relative py-20 sm:py-28 lg:py-32">
-          <p class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-transparent bg-gradient-to-br from-sky-600 to-cyan-400 bg-clip-text">
-            Regenfass
-          </p>
-          <h1 class="mt-4 max-w-2xl text-2xl sm:text-3xl lg:text-4xl font-semibold tracking-tight text-foreground">
-            Know your rain barrel’s water level—wirelessly.
-          </h1>
-          <p class="mt-4 max-w-xl text-base sm:text-lg text-muted-foreground">
-            Open-source fill-level sensing for tanks and barrels, over LoRaWAN
-            and The Things Network—built by TTN Leipzig.
-          </p>
-          <div class="mt-8 flex flex-wrap items-center gap-3">
-            <a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
-              <ButtonPrimary class="px-5 py-2.5 text-base">
-                Get started
-              </ButtonPrimary>
-            </a>
-            <a href={DOCS_URL} onClick={trackNavigateToDocs}>
-              <ButtonSecondary class="px-5 py-2.5 text-base">
-                Read docs
-              </ButtonSecondary>
-            </a>
-          </div>
-        </div>
-      </section>
+	const params = useParams();
+	const { locale, setLocale } = useLocale();
+	const t = useMarketingT();
+	const copy = () => marketingCopy(locale());
 
-      {/* 2. Why it matters */}
-      <section class="site-container py-16 sm:py-20 space-y-8">
-        <Headline as="h2" subtitle="Practical reasons people put a sensor on a barrel or tank.">
-          Why it matters
-        </Headline>
-        <div class="grid gap-4 sm:grid-cols-3">
-          <For each={WHY}>
-            {(item) => (
-              <Card>
-                <CardHeader>
-                  <CardTitle>{item.title}</CardTitle>
-                  <CardDescription>{item.body}</CardDescription>
-                </CardHeader>
-              </Card>
-            )}
-          </For>
-        </div>
-      </section>
+	createEffect(() => {
+		const lang = params.lang;
+		if (!isLocale(lang)) return;
+		if (locale() !== lang) {
+			setLocale(lang, { announce: false });
+		}
+		applyMarketingSeo(lang);
+	});
 
-      {/* 3. How it works */}
-      <section class="border-y border-border bg-card/40">
-        <div class="site-container py-16 sm:py-20 space-y-8">
-          <Headline as="h2" subtitle="From the water surface to a dashboard you already use.">
-            How it works
-          </Headline>
-          <ol class="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
-            <For each={STEPS}>
-              {(item) => (
-                <li class="rounded-lg border border-border bg-background p-4 space-y-2">
-                  <Badge class="font-mono">{item.step}</Badge>
-                  <p class="font-semibold text-foreground">{item.title}</p>
-                  <p class="text-sm text-muted-foreground">{item.body}</p>
-                </li>
-              )}
-            </For>
-          </ol>
-        </div>
-      </section>
+	return (
+		<Show
+			when={isLocale(params.lang) ? params.lang : null}
+			fallback={<InvalidLocaleRedirect />}
+		>
+			{(lang) => (
+				<Shell lang={lang()}>
+					<section class="relative overflow-hidden hero-glow">
+						<div
+							class="absolute inset-0 grid-quiet pointer-events-none"
+							aria-hidden="true"
+						/>
+						<div class="site-container relative py-20 sm:py-28 lg:py-32">
+							<p class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-transparent bg-gradient-to-br from-sky-600 to-cyan-400 bg-clip-text">
+								Regenfass
+							</p>
+							<h1 class="mt-4 max-w-2xl text-2xl sm:text-3xl lg:text-4xl font-semibold tracking-tight text-foreground">
+								{t("hero.headline")}
+							</h1>
+							<p class="mt-4 max-w-xl text-base sm:text-lg text-muted-foreground">
+								{t("hero.body")}
+							</p>
+							<div class="mt-8 flex flex-wrap items-center gap-3">
+								<a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
+									<ButtonPrimary class="px-5 py-2.5 text-base">
+										{t("hero.ctaStart")}
+									</ButtonPrimary>
+								</a>
+								<a href={DOCS_URL} onClick={trackNavigateToDocs}>
+									<ButtonSecondary class="px-5 py-2.5 text-base">
+										{t("hero.ctaDocs")}
+									</ButtonSecondary>
+								</a>
+							</div>
+						</div>
+					</section>
 
-      {/* 4. Hardware */}
-      <section class="site-container py-16 sm:py-20 space-y-8">
-        <Headline
-          as="h2"
-          subtitle="A small parts list most makers already recognize."
-        >
-          Hardware overview
-        </Headline>
-        <div class="grid gap-6 sm:grid-cols-3">
-          <For each={HARDWARE}>
-            {(item) => (
-              <Card>
-                <CardHeader class="items-start gap-3">
-                  <img
-                    src={item.src}
-                    alt=""
-                    class="h-24 w-auto object-contain"
-                    loading="lazy"
-                  />
-                  <CardTitle>{item.title}</CardTitle>
-                  <CardDescription>{item.body}</CardDescription>
-                </CardHeader>
-              </Card>
-            )}
-          </For>
-        </div>
-        <p class="text-sm text-muted-foreground">
-          Full bill of materials and wiring diagrams live in the{" "}
-          <Link href={DOCS_URL} onClick={trackNavigateToDocs}>
-            documentation
-          </Link>
-          .
-        </p>
-      </section>
+					<section class="site-container py-16 sm:py-20 space-y-8">
+						<Headline as="h2" subtitle={t("why.subtitle")}>
+							{t("why.title")}
+						</Headline>
+						<div class="grid gap-4 sm:grid-cols-3">
+							<For each={[...copy().why.items]}>
+								{(item) => (
+									<Card>
+										<CardHeader>
+											<CardTitle>{item.title}</CardTitle>
+											<CardDescription>{item.body}</CardDescription>
+										</CardHeader>
+									</Card>
+								)}
+							</For>
+						</div>
+					</section>
 
-      {/* 5. Software */}
-      <section class="border-y border-border bg-card/40">
-        <div class="site-container py-16 sm:py-20 grid gap-10 lg:grid-cols-2 lg:items-center">
-          <div class="space-y-4">
-            <Headline as="h2">Software you flash in the browser</Headline>
-            <p class="text-muted-foreground max-w-prose">
-              The web installer uses Web Serial—no desktop IDE required for a
-              first flash. Firmware and the installer are open source under the
-              project’s license on GitHub.
-            </p>
-            <div class="flex flex-wrap gap-3 pt-2">
-              <a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
-                <ButtonPrimary>Open installer</ButtonPrimary>
-              </a>
-              <Link href="https://github.com/ttnleipzig/regenfass">
-                View source on GitHub
-              </Link>
-            </div>
-          </div>
-          <Card>
-            <CardHeader>
-              <CardTitle>What you get</CardTitle>
-            </CardHeader>
-            <CardContent class="space-y-2 text-sm text-muted-foreground">
-              <p>• Browser-based flashing and device configuration</p>
-              <p>• LoRaWAN OTAA credentials for The Things Network</p>
-              <p>• Hooks into MQTT, Node-RED, and Grafana stacks</p>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
+					<section class="border-y border-border bg-card/40">
+						<div class="site-container py-16 sm:py-20 space-y-8">
+							<Headline as="h2" subtitle={t("how.subtitle")}>
+								{t("how.title")}
+							</Headline>
+							<ol class="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+								<For each={[...copy().how.steps]}>
+									{(item) => (
+										<li class="rounded-lg border border-border bg-background p-4 space-y-2">
+											<Badge class="font-mono">{item.step}</Badge>
+											<p class="font-semibold text-foreground">{item.title}</p>
+											<p class="text-sm text-muted-foreground">{item.body}</p>
+										</li>
+									)}
+								</For>
+							</ol>
+						</div>
+					</section>
 
-      {/* 6. Typical use cases */}
-      <section class="site-container py-16 sm:py-20 space-y-8">
-        <Headline as="h2">Typical use cases</Headline>
-        <div class="grid gap-4 sm:grid-cols-3">
-          <For each={CASES}>
-            {(item) => (
-              <Card>
-                <CardHeader>
-                  <CardTitle>{item.title}</CardTitle>
-                  <CardDescription>{item.body}</CardDescription>
-                </CardHeader>
-              </Card>
-            )}
-          </For>
-        </div>
-      </section>
+					<section class="site-container py-16 sm:py-20 space-y-8">
+						<Headline as="h2" subtitle={t("hardware.subtitle")}>
+							{t("hardware.title")}
+						</Headline>
+						<div class="grid gap-6 sm:grid-cols-3">
+							<For each={[...copy().hardware.items]}>
+								{(item) => (
+									<Card>
+										<CardHeader class="items-start gap-3">
+											<img
+												src={item.src}
+												alt=""
+												class="h-24 w-auto object-contain"
+												loading="lazy"
+											/>
+											<CardTitle>{item.title}</CardTitle>
+											<CardDescription>{item.body}</CardDescription>
+										</CardHeader>
+									</Card>
+								)}
+							</For>
+						</div>
+						<p class="text-sm text-muted-foreground">
+							{t("hardware.docsBefore")}{" "}
+							<Link href={DOCS_URL} onClick={trackNavigateToDocs}>
+								{t("hardware.docsLink")}
+							</Link>
+							{t("hardware.docsAfter")}
+						</p>
+					</section>
 
-      {/* 7. Changelog / release notes */}
-      <ChangelogSection />
+					<section class="border-y border-border bg-card/40">
+						<div class="site-container py-16 sm:py-20 grid gap-10 lg:grid-cols-2 lg:items-center">
+							<div class="space-y-4">
+								<Headline as="h2">{t("software.title")}</Headline>
+								<p class="text-muted-foreground max-w-prose">{t("software.body")}</p>
+								<div class="flex flex-wrap gap-3 pt-2">
+									<a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
+										<ButtonPrimary>{t("software.openInstaller")}</ButtonPrimary>
+									</a>
+									<Link href="https://github.com/ttnleipzig/regenfass">
+										{t("software.viewSource")}
+									</Link>
+								</div>
+							</div>
+							<Card>
+								<CardHeader>
+									<CardTitle>{t("software.whatYouGet")}</CardTitle>
+								</CardHeader>
+								<CardContent class="space-y-2 text-sm text-muted-foreground">
+									<For each={[...copy().software.bullets]}>
+										{(bullet) => <p>• {bullet}</p>}
+									</For>
+								</CardContent>
+							</Card>
+						</div>
+					</section>
 
-      {/* 8. CTA strip */}
-      <section class="border-t border-border bg-gradient-to-br from-sky-600/10 to-cyan-500/5">
-        <div class="site-container py-14 sm:py-16 space-y-6">
-          <Headline as="h2" align="center">
-            Ready to measure?
-          </Headline>
-          <p class="text-center text-muted-foreground max-w-xl mx-auto">
-            Flash a board in minutes, join The Things Network, and start
-            reading your rain barrel from anywhere with coverage.
-          </p>
-          <div class="flex flex-wrap justify-center gap-3">
-            <a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
-              <ButtonPrimary class="px-5 py-2.5">Get started</ButtonPrimary>
-            </a>
-            <a href={DOCS_URL} onClick={trackNavigateToDocs}>
-              <ButtonSecondary class="px-5 py-2.5">Read the docs</ButtonSecondary>
-            </a>
-          </div>
-          <div class="max-w-lg mx-auto pt-4">
-            <Newsletter />
-          </div>
-        </div>
-      </section>
-    </Shell>
-  );
+					<section class="site-container py-16 sm:py-20 space-y-8">
+						<Headline as="h2">{t("cases.title")}</Headline>
+						<div class="grid gap-4 sm:grid-cols-3">
+							<For each={[...copy().cases.items]}>
+								{(item) => (
+									<Card>
+										<CardHeader>
+											<CardTitle>{item.title}</CardTitle>
+											<CardDescription>{item.body}</CardDescription>
+										</CardHeader>
+									</Card>
+								)}
+							</For>
+						</div>
+					</section>
+
+					<ChangelogSection />
+
+					<section class="border-t border-border bg-gradient-to-br from-sky-600/10 to-cyan-500/5">
+						<div class="site-container py-14 sm:py-16 space-y-6">
+							<Headline as="h2" align="center">
+								{t("cta.title")}
+							</Headline>
+							<p class="text-center text-muted-foreground max-w-xl mx-auto">
+								{t("cta.body")}
+							</p>
+							<div class="flex flex-wrap justify-center gap-3">
+								<a href={INSTALLER_URL} onClick={trackNavigateToInstaller}>
+									<ButtonPrimary class="px-5 py-2.5">{t("cta.ctaStart")}</ButtonPrimary>
+								</a>
+								<a href={DOCS_URL} onClick={trackNavigateToDocs}>
+									<ButtonSecondary class="px-5 py-2.5">
+										{t("cta.ctaDocs")}
+									</ButtonSecondary>
+								</a>
+							</div>
+							<div class="max-w-lg mx-auto pt-4">
+								<Newsletter />
+							</div>
+						</div>
+					</section>
+				</Shell>
+			)}
+		</Show>
+	);
+}
+
+function initialMarketingLocale(): Locale {
+	if (typeof location !== "undefined") {
+		const segment = location.pathname.split("/").filter(Boolean)[0];
+		if (isLocale(segment)) return segment;
+	}
+	return resolveLocale();
+}
+
+function MarketingRoot(props: RouteSectionProps) {
+	const navigate = useNavigate();
+
+	return (
+		<LocaleProvider
+			initialLocale={initialMarketingLocale()}
+			onLocaleChange={(next) => {
+				const hash = typeof location !== "undefined" ? location.hash : "";
+				navigate(`/${next}${hash}`);
+			}}
+		>
+			{props.children}
+		</LocaleProvider>
+	);
 }
 
 export default function App() {
-  return (
-    <Router>
-      <Route path="/" component={Home} />
-    </Router>
-  );
+	return (
+		<Router root={MarketingRoot}>
+			<Route path="/" component={LocaleRedirect} />
+			<Route path="/:lang" component={Home} />
+		</Router>
+	);
 }

--- a/web/marketing/src/ChangelogSection.tsx
+++ b/web/marketing/src/ChangelogSection.tsx
@@ -2,27 +2,26 @@ import { createMemo } from "solid-js";
 import { marked } from "marked";
 import changelogMarkdown from "../../../CHANGELOG.md?raw";
 import { APP_VERSION, Headline, Link } from "@regenfass/brand";
+import { useMarketingT } from "./i18n/index.ts";
 
 /** Renders the repo CHANGELOG.md (same notes Release Please puts on GitHub Releases). */
 export default function ChangelogSection() {
+	const t = useMarketingT();
 	const html = createMemo(() =>
 		marked.parse(changelogMarkdown, { async: false }) as string,
 	);
 
 	return (
 		<section id="changelog" class="site-container py-16 sm:py-20 space-y-6">
-			<Headline
-				as="h2"
-				subtitle="Same notes as on GitHub Releases — written by Release Please from Conventional Commits."
-			>
-				Changelog
+			<Headline as="h2" subtitle={t("changelog.subtitle")}>
+				{t("changelog.title")}
 			</Headline>
 			<p class="text-sm text-muted-foreground">
-				Current release:{" "}
+				{t("changelog.currentRelease")}{" "}
 				<span class="font-mono text-foreground">v{APP_VERSION}</span>
 				{" · "}
 				<Link href="https://github.com/ttnleipzig/regenfass/releases">
-					Open on GitHub
+					{t("changelog.openOnGitHub")}
 				</Link>
 			</p>
 			<article

--- a/web/marketing/src/i18n/de.ts
+++ b/web/marketing/src/i18n/de.ts
@@ -1,0 +1,139 @@
+import type { MarketingDictionary } from "./en.ts";
+
+export const marketingDictDe: MarketingDictionary = {
+	meta: {
+		title: "Regenfass – smarte Regenfass-Überwachung",
+		description:
+			"Regenfass misst den Wasserstand in Regenfassern und Tanks und sendet Messwerte per LoRaWAN über The Things Network. Open-Source-IoT von TTN Leipzig.",
+	},
+	nav: {
+		home: "Home",
+		changelog: "Changelog",
+		docs: "Docs",
+		installer: "Installer",
+		brand: "Brand",
+		github: "GitHub",
+	},
+	hero: {
+		headline: "Kenn den Wasserstand deines Regenfasses — kabellos.",
+		body: "Open-Source-Füllstandmessung für Tanks und Fässer, über LoRaWAN und The Things Network — gebaut von TTN Leipzig.",
+		ctaStart: "Loslegen",
+		ctaDocs: "Docs lesen",
+	},
+	why: {
+		title: "Warum das zählt",
+		subtitle:
+			"Praktische Gründe, einen Sensor an Fass oder Tank zu setzen.",
+		items: [
+			{
+				title: "Regenfässer zu Hause",
+				body: "Wisse, wie viel Wasser nach einer Trockenphase noch da ist — vor dem nächsten Gießen.",
+			},
+			{
+				title: "Gemeinschaftsgärten",
+				body: "Teile einen klaren Füllstand, damit alle fair und sparsam gießen können.",
+			},
+			{
+				title: "Größere Tanks",
+				body: "Überwache Zisternen und Speichertanks, ohne Deckel zu öffnen oder mit dem Messstab zu raten.",
+			},
+		],
+	},
+	how: {
+		title: "So funktioniert’s",
+		subtitle: "Von der Wasseroberfläche zum Dashboard, das du schon nutzt.",
+		steps: [
+			{
+				step: "1",
+				title: "Messen",
+				body: "Ein Ultraschall- oder ToF-Sensor misst den Abstand zur Wasseroberfläche.",
+			},
+			{
+				step: "2",
+				title: "Rechnen",
+				body: "Ein ESP32 wandelt den Abstand gerätenah in den Füllstand um.",
+			},
+			{
+				step: "3",
+				title: "Senden",
+				body: "LoRaWAN überträgt kleine Payloads über große Distanzen mit wenig Energie.",
+			},
+			{
+				step: "4",
+				title: "Netzwerk",
+				body: "The Things Network leitet Nachrichten an die Apps weiter, die du wählst.",
+			},
+			{
+				step: "5",
+				title: "Dashboard",
+				body: "Sieh Trends in Grafana, Node-RED oder jedem MQTT-fähigen Tool.",
+			},
+		],
+	},
+	hardware: {
+		title: "Hardware im Überblick",
+		subtitle: "Eine kleine Teileliste, die viele Maker schon kennen.",
+		items: [
+			{
+				title: "Heltec WiFi LoRa 32",
+				body: "ESP32 mit eingebautem LoRa-Radio — flashen und konfigurieren im Browser.",
+				src: "/img/hardware-esplora.svg",
+			},
+			{
+				title: "HC-SR04 (und Co.)",
+				body: "Günstige Ultraschallmessung für Prototypen; wasserdichte Optionen für längere Installationen.",
+				src: "/img/sensor-hcsr04.svg",
+			},
+			{
+				title: "Strom & Gehäuse",
+				body: "Optionales OLED-Display, 18650-Zellen und ein wettertaugliches Gehäuse für draußen.",
+				src: "/img/hardware-18650.svg",
+			},
+		],
+		docsBefore: "Stückliste und Schaltpläne findest du in der",
+		docsLink: "Dokumentation",
+		docsAfter: ".",
+	},
+	software: {
+		title: "Software, die du im Browser flashst",
+		body: "Der Web-Installer nutzt Web Serial — für den ersten Flash brauchst du keine Desktop-IDE. Firmware und Installer sind Open Source unter der Projektlizenz auf GitHub.",
+		openInstaller: "Installer öffnen",
+		viewSource: "Quellcode auf GitHub",
+		whatYouGet: "Was du bekommst",
+		bullets: [
+			"Flashen und Gerätekonfiguration im Browser",
+			"LoRaWAN-OTAA-Zugangsdaten für The Things Network",
+			"Anbindung an MQTT-, Node-RED- und Grafana-Stacks",
+		],
+	},
+	cases: {
+		title: "Typische Einsatzfälle",
+		items: [
+			{
+				title: "Entscheidungen beim Gießen",
+				body: "Weg mit dem Raten: öffne ein Diagramm und entscheide, ob heute gegossen wird.",
+			},
+			{
+				title: "Hinweise bei Trockenheit",
+				body: "Erkenne leere oder fast leere Tanks früh bei Hitzewellen und trockenen Wochen.",
+			},
+			{
+				title: "Gemeinsame Sichtbarkeit",
+				body: "Gib Kleingarten- oder Schulgarten-Gruppen eine gemeinsame Messquelle.",
+			},
+		],
+	},
+	changelog: {
+		title: "Changelog",
+		subtitle:
+			"Dieselben Notizen wie auf GitHub Releases — geschrieben von Release Please aus Conventional Commits.",
+		currentRelease: "Aktuelles Release:",
+		openOnGitHub: "Auf GitHub öffnen",
+	},
+	cta: {
+		title: "Bereit zum Messen?",
+		body: "Flashe ein Board in Minuten, tritt The Things Network bei und lies dein Regenfass überall dort, wo Coverage ist.",
+		ctaStart: "Loslegen",
+		ctaDocs: "Docs lesen",
+	},
+};

--- a/web/marketing/src/i18n/en.ts
+++ b/web/marketing/src/i18n/en.ts
@@ -1,0 +1,138 @@
+export const marketingDictEn = {
+	meta: {
+		title: "Regenfass – smart rain barrel monitoring",
+		description:
+			"Regenfass measures water level in rain barrels and tanks, and sends readings over LoRaWAN via The Things Network. Open source IoT by TTN Leipzig.",
+	},
+	nav: {
+		home: "Home",
+		changelog: "Changelog",
+		docs: "Docs",
+		installer: "Installer",
+		brand: "Brand",
+		github: "GitHub",
+	},
+	hero: {
+		headline: "Know your rain barrel’s water level—wirelessly.",
+		body: "Open-source fill-level sensing for tanks and barrels, over LoRaWAN and The Things Network—built by TTN Leipzig.",
+		ctaStart: "Get started",
+		ctaDocs: "Read docs",
+	},
+	why: {
+		title: "Why it matters",
+		subtitle: "Practical reasons people put a sensor on a barrel or tank.",
+		items: [
+			{
+				title: "Home rain barrels",
+				body: "Know how much water is left after a dry spell—before the next watering session.",
+			},
+			{
+				title: "Community gardens",
+				body: "Share a clear fill level with gardeners so everyone can water fairly and sparingly.",
+			},
+			{
+				title: "Larger tanks",
+				body: "Monitor cisterns and storage tanks without climbing lids or guessing from a dip stick.",
+			},
+		],
+	},
+	how: {
+		title: "How it works",
+		subtitle: "From the water surface to a dashboard you already use.",
+		steps: [
+			{
+				step: "1",
+				title: "Sense",
+				body: "An ultrasonic or ToF sensor reads distance to the water surface.",
+			},
+			{
+				step: "2",
+				title: "Compute",
+				body: "An ESP32 board converts distance into fill level on device.",
+			},
+			{
+				step: "3",
+				title: "Transmit",
+				body: "LoRaWAN sends small payloads over long range with low power.",
+			},
+			{
+				step: "4",
+				title: "Network",
+				body: "The Things Network routes messages to apps you choose.",
+			},
+			{
+				step: "5",
+				title: "Dashboard",
+				body: "View trends in Grafana, Node-RED, or any MQTT-ready tool.",
+			},
+		],
+	},
+	hardware: {
+		title: "Hardware overview",
+		subtitle: "A small parts list most makers already recognize.",
+		items: [
+			{
+				title: "Heltec WiFi LoRa 32",
+				body: "ESP32 with onboard LoRa radio—flash and configure from the browser.",
+				src: "/img/hardware-esplora.svg",
+			},
+			{
+				title: "HC-SR04 (and friends)",
+				body: "Affordable ultrasonic sensing for prototypes; waterproof options for longer installs.",
+				src: "/img/sensor-hcsr04.svg",
+			},
+			{
+				title: "Power & housing",
+				body: "Optional OLED display, 18650 cells, and a weather-minded enclosure for outdoor use.",
+				src: "/img/hardware-18650.svg",
+			},
+		],
+		docsBefore: "Full bill of materials and wiring diagrams live in the",
+		docsLink: "documentation",
+		docsAfter: ".",
+	},
+	software: {
+		title: "Software you flash in the browser",
+		body: "The web installer uses Web Serial—no desktop IDE required for a first flash. Firmware and the installer are open source under the project’s license on GitHub.",
+		openInstaller: "Open installer",
+		viewSource: "View source on GitHub",
+		whatYouGet: "What you get",
+		bullets: [
+			"Browser-based flashing and device configuration",
+			"LoRaWAN OTAA credentials for The Things Network",
+			"Hooks into MQTT, Node-RED, and Grafana stacks",
+		],
+	},
+	cases: {
+		title: "Typical use cases",
+		items: [
+			{
+				title: "Garden watering decisions",
+				body: "Skip the guesswork: open a chart and decide whether to irrigate today.",
+			},
+			{
+				title: "Seasonal dryness alerts",
+				body: "Catch empty or near-empty tanks early during heatwaves and dry weeks.",
+			},
+			{
+				title: "Shared site visibility",
+				body: "Give allotment or school garden groups one shared reading source.",
+			},
+		],
+	},
+	changelog: {
+		title: "Changelog",
+		subtitle:
+			"Same notes as on GitHub Releases — written by Release Please from Conventional Commits.",
+		currentRelease: "Current release:",
+		openOnGitHub: "Open on GitHub",
+	},
+	cta: {
+		title: "Ready to measure?",
+		body: "Flash a board in minutes, join The Things Network, and start reading your rain barrel from anywhere with coverage.",
+		ctaStart: "Get started",
+		ctaDocs: "Read the docs",
+	},
+} as const;
+
+export type MarketingDictionary = typeof marketingDictEn;

--- a/web/marketing/src/i18n/en.ts
+++ b/web/marketing/src/i18n/en.ts
@@ -1,4 +1,67 @@
-export const marketingDictEn = {
+export type MarketingDictionary = {
+	meta: {
+		title: string;
+		description: string;
+	};
+	nav: {
+		home: string;
+		changelog: string;
+		docs: string;
+		installer: string;
+		brand: string;
+		github: string;
+	};
+	hero: {
+		headline: string;
+		body: string;
+		ctaStart: string;
+		ctaDocs: string;
+	};
+	why: {
+		title: string;
+		subtitle: string;
+		items: { title: string; body: string }[];
+	};
+	how: {
+		title: string;
+		subtitle: string;
+		steps: { step: string; title: string; body: string }[];
+	};
+	hardware: {
+		title: string;
+		subtitle: string;
+		items: { title: string; body: string; src: string }[];
+		docsBefore: string;
+		docsLink: string;
+		docsAfter: string;
+	};
+	software: {
+		title: string;
+		body: string;
+		openInstaller: string;
+		viewSource: string;
+		whatYouGet: string;
+		bullets: string[];
+	};
+	cases: {
+		title: string;
+		items: { title: string; body: string }[];
+	};
+	changelog: {
+		title: string;
+		subtitle: string;
+		currentRelease: string;
+		openOnGitHub: string;
+	};
+	cta: {
+		title: string;
+		body: string;
+		ctaStart: string;
+		ctaDocs: string;
+	};
+};
+
+export const marketingDictEn: MarketingDictionary = {
 	meta: {
 		title: "Regenfass – smart rain barrel monitoring",
 		description:
@@ -133,6 +196,4 @@ export const marketingDictEn = {
 		ctaStart: "Get started",
 		ctaDocs: "Read the docs",
 	},
-} as const;
-
-export type MarketingDictionary = typeof marketingDictEn;
+};

--- a/web/marketing/src/i18n/index.ts
+++ b/web/marketing/src/i18n/index.ts
@@ -1,0 +1,34 @@
+import { createMemo } from "solid-js";
+import {
+	flatten,
+	resolveTemplate,
+	translator,
+	type Flatten,
+	type Translator,
+} from "@solid-primitives/i18n";
+import {
+	useLocale,
+	type Locale,
+} from "@regenfass/brand";
+import { marketingDictDe } from "./de.ts";
+import { marketingDictEn, type MarketingDictionary } from "./en.ts";
+
+export type { MarketingDictionary };
+export { marketingDictDe, marketingDictEn };
+
+export const marketingDictionaries: Record<Locale, MarketingDictionary> = {
+	de: marketingDictDe,
+	en: marketingDictEn,
+};
+
+export type FlatMarketingDictionary = Flatten<MarketingDictionary>;
+
+export function useMarketingT(): Translator<FlatMarketingDictionary> {
+	const { locale } = useLocale();
+	const dict = createMemo(() => flatten(marketingDictionaries[locale()]));
+	return translator(dict, resolveTemplate);
+}
+
+export function marketingCopy(locale: Locale): MarketingDictionary {
+	return marketingDictionaries[locale];
+}

--- a/web/marketing/src/i18n/localeRouting.ts
+++ b/web/marketing/src/i18n/localeRouting.ts
@@ -1,0 +1,15 @@
+import { isLocale, resolveLocale, type Locale } from "@regenfass/brand";
+
+/** Resolve `/` redirect target, preserving hash. */
+export function localeRedirectPath(
+	cookieHeader?: string | null,
+	languages?: readonly string[],
+	hash = "",
+): string {
+	return `/${resolveLocale(cookieHeader, languages)}${hash}`;
+}
+
+/** Normalize `/:lang` — return locale or null when invalid. */
+export function parseLocaleParam(lang: string | undefined): Locale | null {
+	return isLocale(lang) ? lang : null;
+}

--- a/web/marketing/src/i18n/seo.ts
+++ b/web/marketing/src/i18n/seo.ts
@@ -1,0 +1,43 @@
+import type { Locale } from "@regenfass/brand";
+import { marketingCopy } from "./index.ts";
+
+const SITE_ORIGIN = "https://regenfass.eu";
+
+function upsertMeta(selector: string, attr: "name" | "property", key: string, content: string) {
+	let el = document.head.querySelector(selector);
+	if (!el) {
+		el = document.createElement("meta");
+		el.setAttribute(attr, key);
+		document.head.appendChild(el);
+	}
+	el.setAttribute("content", content);
+}
+
+function upsertLink(rel: string, hreflang: string | undefined, href: string) {
+	const selector = hreflang
+		? `link[rel="${rel}"][hreflang="${hreflang}"]`
+		: `link[rel="${rel}"]:not([hreflang])`;
+	let el = document.head.querySelector(selector) as HTMLLinkElement | null;
+	if (!el) {
+		el = document.createElement("link");
+		el.rel = rel;
+		if (hreflang) el.hreflang = hreflang;
+		document.head.appendChild(el);
+	}
+	el.href = href;
+}
+
+/** Update document title, description, canonical, and hreflang for the active locale. */
+export function applyMarketingSeo(locale: Locale) {
+	const copy = marketingCopy(locale);
+	document.title = copy.meta.title;
+	document.documentElement.lang = locale;
+
+	upsertMeta('meta[name="description"]', "name", "description", copy.meta.description);
+
+	const canonical = `${SITE_ORIGIN}/${locale}`;
+	upsertLink("canonical", undefined, canonical);
+	upsertLink("alternate", "de", `${SITE_ORIGIN}/de`);
+	upsertLink("alternate", "en", `${SITE_ORIGIN}/en`);
+	upsertLink("alternate", "x-default", `${SITE_ORIGIN}/en`);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds German and English localization for the marketing site and installer.

- Shared locale plumbing in `@regenfass/brand`: cookie `regenfass-locale` (synced on `.regenfass.eu`), browser detection, `LocaleProvider`, and header `LanguageSwitcher`
- Marketing: SEO routes `/de` and `/en`, `/` redirects from cookie/browser, hreflang/meta updates
- Installer: same cookie + reactive UI; language is **not** reflected in the URL
- Live installer step copy and user-facing config/state errors are translated

## Test plan

- [ ] `pnpm --filter @ttnleipzig/regenfass-installer test:run`
- [ ] `pnpm --filter @ttnleipzig/regenfass-marketing lint:ts` / build
- [ ] Marketing: open `/` → lands on `/de` or `/en`; switcher changes path + cookie
- [ ] Installer: switcher changes copy only; URL stays `/`
- [ ] Cookie set on marketing applies on installer (production domains)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36a9e81c-632c-43b8-85ec-c75f5b0eb9fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36a9e81c-632c-43b8-85ec-c75f5b0eb9fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

