### PR TITLE
fix(marketing): sync dark mode on first paint

### DIFF
--- a/web/brand-showcase/index.html
+++ b/web/brand-showcase/index.html
@@ -8,6 +8,25 @@
       name="description"
       content="Shared UI components and design tokens for Regenfass web apps."
     />
+    <!-- Sync Tailwind .dark + Kobalte data-kb-theme before first paint -->
+    <script>
+      (() => {
+        try {
+          const saved =
+            localStorage.getItem("kb-color-mode") ||
+            localStorage.getItem("theme");
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          const isDark =
+            saved === "dark" || (saved !== "light" && prefersDark);
+          const root = document.documentElement;
+          root.classList.toggle("dark", isDark);
+          root.setAttribute("data-kb-theme", isDark ? "dark" : "light");
+          root.style.colorScheme = isDark ? "dark" : "light";
+        } catch {}
+      })();
+    </script>
   </head>
   <body
     class="min-h-screen min-h-dvh bg-fixed text-slate-700 dark:text-slate-100 bg-slate-100 dark:bg-slate-900"

--- a/web/brand-showcase/src/index.tsx
+++ b/web/brand-showcase/src/index.tsx
@@ -1,9 +1,11 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
-import { initAnalytics } from "@regenfass/brand";
+import { initAnalytics, initColorMode } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
+
+initColorMode();
 
 initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
   apiURL: import.meta.env.VITE_SWETRIX_API_URL,

--- a/web/brand-showcase/tailwind.config.js
+++ b/web/brand-showcase/tailwind.config.js
@@ -3,7 +3,7 @@ import brandPreset from "@regenfass/brand/tailwind.preset.cjs";
 /** @type {import('tailwindcss').Config} */
 export default {
   presets: [brandPreset],
-  darkMode: "class",
+  darkMode: ["selector", ':is(.dark, [data-kb-theme="dark"])'],
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/web/brand/src/components/atoms/ButtonModeToggle.tsx
+++ b/web/brand/src/components/atoms/ButtonModeToggle.tsx
@@ -1,22 +1,24 @@
+import { createEffect } from "solid-js";
 import { Button } from "./Button.tsx";
 import Moon from "lucide-solid/icons/moon";
 import Sun from "lucide-solid/icons/sun";
 import { useColorMode } from "@kobalte/core/color-mode";
 import { trackEvent } from "../../libs/analytics.ts";
+import { applyColorMode, persistColorMode } from "../../libs/colorMode.ts";
 
 export function ButtonModeToggle() {
 	const { colorMode, setColorMode } = useColorMode();
 
+	// Keep Tailwind `.dark` aligned with Kobalte after hydrate / system changes.
+	createEffect(() => {
+		applyColorMode(colorMode() === "dark" ? "dark" : "light");
+	});
+
 	const toggle = () => {
 		const next = colorMode() === "light" ? "dark" : "light";
 		setColorMode(next);
-		const isDark = next === "dark";
-		const root = document.documentElement;
-		root.classList.toggle("dark", isDark);
-		root.setAttribute("data-kb-theme", isDark ? "dark" : "light");
-		try {
-			localStorage.setItem("theme", isDark ? "dark" : "light");
-		} catch {}
+		applyColorMode(next);
+		persistColorMode(next);
 		trackEvent("theme_toggled", { theme: next });
 	};
 
@@ -51,5 +53,3 @@ export function ButtonModeToggle() {
 		</Button>
 	);
 }
-
-

--- a/web/brand/src/index.ts
+++ b/web/brand/src/index.ts
@@ -92,6 +92,15 @@ export { TextInput } from "./components/forms/TextInput.tsx";
 // Utils
 export { cn } from "./libs/cn.ts";
 export {
+  applyColorMode,
+  initColorMode,
+  persistColorMode,
+  resolveColorMode,
+  KB_COLOR_MODE_STORAGE_KEY,
+  LEGACY_THEME_STORAGE_KEY,
+} from "./libs/colorMode.ts";
+export type { ResolvedColorMode } from "./libs/colorMode.ts";
+export {
   initAnalytics,
   isAnalyticsInitialized,
   trackEvent,

--- a/web/brand/src/libs/colorMode.ts
+++ b/web/brand/src/libs/colorMode.ts
@@ -1,0 +1,61 @@
+/** localStorage key used by @kobalte/core ColorModeProvider */
+export const KB_COLOR_MODE_STORAGE_KEY = "kb-color-mode";
+
+/** Legacy key written by ButtonModeToggle before Kobalte sync */
+export const LEGACY_THEME_STORAGE_KEY = "theme";
+
+export type ResolvedColorMode = "light" | "dark";
+
+/**
+ * Resolve the effective light/dark mode from storage or system preference.
+ * Treats Kobalte's `"system"` value (and missing keys) as matchMedia.
+ */
+export function resolveColorMode(): ResolvedColorMode {
+	try {
+		const saved =
+			localStorage.getItem(KB_COLOR_MODE_STORAGE_KEY) ??
+			localStorage.getItem(LEGACY_THEME_STORAGE_KEY);
+		if (saved === "light" || saved === "dark") return saved;
+	} catch {
+		/* ignore */
+	}
+	const prefersDark =
+		typeof window !== "undefined" &&
+		typeof window.matchMedia === "function" &&
+		window.matchMedia("(prefers-color-scheme: dark)").matches;
+	return prefersDark ? "dark" : "light";
+}
+
+/**
+ * Apply both Tailwind `.dark` and Kobalte `data-kb-theme` so token CSS and
+ * `dark:` utilities stay in sync.
+ */
+export function applyColorMode(mode: ResolvedColorMode): void {
+	const root = document.documentElement;
+	const isDark = mode === "dark";
+	root.classList.toggle("dark", isDark);
+	root.setAttribute("data-kb-theme", mode);
+	root.style.colorScheme = mode;
+}
+
+/** Persist explicit light/dark for both Kobalte and legacy readers. */
+export function persistColorMode(mode: ResolvedColorMode): void {
+	try {
+		localStorage.setItem(KB_COLOR_MODE_STORAGE_KEY, mode);
+		localStorage.setItem(LEGACY_THEME_STORAGE_KEY, mode);
+	} catch {
+		/* ignore */
+	}
+}
+
+/**
+ * Bootstrap color mode before first paint / Solid hydrate.
+ * Call once at app entry (and mirror as a blocking script in index.html).
+ */
+export function initColorMode(): void {
+	try {
+		applyColorMode(resolveColorMode());
+	} catch {
+		/* ignore */
+	}
+}

--- a/web/brand/tailwind.preset.cjs
+++ b/web/brand/tailwind.preset.cjs
@@ -1,6 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: "class",
+  // Match both Tailwind `.dark` and Kobalte `data-kb-theme` so dark: utilities
+  // work even when only one of the two theme switches is set.
+  darkMode: ["selector", ':is(.dark, [data-kb-theme="dark"])'],
   theme: {
     extend: {
       colors: {

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -9,6 +9,25 @@
       content="Friendly guides for building, flashing, and using Regenfass rain-barrel sensors."
     />
     <link rel="canonical" href="https://docs.regenfass.eu/" />
+    <!-- Sync Tailwind .dark + Kobalte data-kb-theme before first paint -->
+    <script>
+      (() => {
+        try {
+          const saved =
+            localStorage.getItem("kb-color-mode") ||
+            localStorage.getItem("theme");
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          const isDark =
+            saved === "dark" || (saved !== "light" && prefersDark);
+          const root = document.documentElement;
+          root.classList.toggle("dark", isDark);
+          root.setAttribute("data-kb-theme", isDark ? "dark" : "light");
+          root.style.colorScheme = isDark ? "dark" : "light";
+        } catch {}
+      })();
+    </script>
   </head>
   <body
     class="min-h-screen min-h-dvh bg-fixed text-slate-700 dark:text-slate-100 bg-slate-100 dark:bg-slate-900"

--- a/web/docs/src/index.tsx
+++ b/web/docs/src/index.tsx
@@ -1,9 +1,11 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
-import { initAnalytics } from "@regenfass/brand";
+import { initAnalytics, initColorMode } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
+
+initColorMode();
 
 initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
   apiURL: import.meta.env.VITE_SWETRIX_API_URL,

--- a/web/docs/tailwind.config.js
+++ b/web/docs/tailwind.config.js
@@ -3,7 +3,7 @@ import brandPreset from "@regenfass/brand/tailwind.preset.cjs";
 /** @type {import('tailwindcss').Config} */
 export default {
   presets: [brandPreset],
-  darkMode: "class",
+  darkMode: ["selector", ':is(.dark, [data-kb-theme="dark"])'],
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/web/installer/index.html
+++ b/web/installer/index.html
@@ -87,6 +87,25 @@
 				}
 			}
 		</script>
+		<!-- Sync Tailwind .dark + Kobalte data-kb-theme before first paint -->
+		<script>
+			(() => {
+				try {
+					const saved =
+						localStorage.getItem("kb-color-mode") ||
+						localStorage.getItem("theme");
+					const prefersDark = window.matchMedia(
+						"(prefers-color-scheme: dark)",
+					).matches;
+					const isDark =
+						saved === "dark" || (saved !== "light" && prefersDark);
+					const root = document.documentElement;
+					root.classList.toggle("dark", isDark);
+					root.setAttribute("data-kb-theme", isDark ? "dark" : "light");
+					root.style.colorScheme = isDark ? "dark" : "light";
+				} catch {}
+			})();
+		</script>
 	</head>
 	<body
 		class="min-h-screen min-h-dvh bg-fixed text-slate-700 dark:text-slate-100 bg-slate-100 dark:bg-slate-900 shadow-[inset_0px_-4px_50px_#46464610] dark:shadow-[inset_0px_-4px_144px_#46466644]">

--- a/web/installer/src/index.tsx
+++ b/web/installer/src/index.tsx
@@ -1,25 +1,15 @@
 /* @refresh reload */
 import { render } from 'solid-js/web'
-import { initAnalytics } from '@regenfass/brand'
+import { initAnalytics, initColorMode } from '@regenfass/brand'
 
 import './index.css'
 import App from './App'
 
+initColorMode();
+
 initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
   apiURL: import.meta.env.VITE_SWETRIX_API_URL,
 });
-
-// Initialize theme from localStorage or system preference
-(() => {
-  try {
-    const saved = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const isDark = saved ? saved === 'dark' : prefersDark;
-    const root = document.documentElement;
-    root.classList.toggle('dark', isDark);
-    root.setAttribute('data-kb-theme', isDark ? 'dark' : 'light');
-  } catch {}
-})();
 
 const root = document.getElementById('root')
 

--- a/web/installer/tailwind.config.js
+++ b/web/installer/tailwind.config.js
@@ -3,7 +3,7 @@ import brandPreset from "@regenfass/brand/tailwind.preset.cjs";
 /** @type {import('tailwindcss').Config} */
 export default {
   presets: [brandPreset],
-  darkMode: "class",
+  darkMode: ["selector", ':is(.dark, [data-kb-theme="dark"])'],
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/web/installer/tests/components/atoms/ButtonModeToggle.test.tsx
+++ b/web/installer/tests/components/atoms/ButtonModeToggle.test.tsx
@@ -31,6 +31,7 @@ describe("ButtonModeToggle", () => {
     // Clear localStorage before each test (using removeItem for jsdom compatibility)
     try {
       localStorage.removeItem("theme");
+      localStorage.removeItem("kb-color-mode");
     } catch {}
     // Reset document classes
     document.documentElement.classList.remove("dark");
@@ -41,6 +42,7 @@ describe("ButtonModeToggle", () => {
     cleanup();
     try {
       localStorage.removeItem("theme");
+      localStorage.removeItem("kb-color-mode");
     } catch {}
   });
 

--- a/web/marketing/index.html
+++ b/web/marketing/index.html
@@ -9,6 +9,25 @@
       content="Regenfass measures water level in rain barrels and tanks, and sends readings over LoRaWAN via The Things Network. Open source IoT by TTN Leipzig."
     />
     <link rel="canonical" href="https://regenfass.eu/" />
+    <!-- Sync Tailwind .dark + Kobalte data-kb-theme before first paint -->
+    <script>
+      (() => {
+        try {
+          const saved =
+            localStorage.getItem("kb-color-mode") ||
+            localStorage.getItem("theme");
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          const isDark =
+            saved === "dark" || (saved !== "light" && prefersDark);
+          const root = document.documentElement;
+          root.classList.toggle("dark", isDark);
+          root.setAttribute("data-kb-theme", isDark ? "dark" : "light");
+          root.style.colorScheme = isDark ? "dark" : "light";
+        } catch {}
+      })();
+    </script>
   </head>
   <body
     class="min-h-screen min-h-dvh bg-fixed text-slate-700 dark:text-slate-100 bg-slate-100 dark:bg-slate-900"

--- a/web/marketing/src/index.tsx
+++ b/web/marketing/src/index.tsx
@@ -1,9 +1,11 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { ColorModeProvider, ColorModeScript } from "@kobalte/core/color-mode";
-import { initAnalytics } from "@regenfass/brand";
+import { initAnalytics, initColorMode } from "@regenfass/brand";
 import App from "./App";
 import "./index.css";
+
+initColorMode();
 
 initAnalytics(import.meta.env.VITE_SWETRIX_PROJECT_ID, {
   apiURL: import.meta.env.VITE_SWETRIX_API_URL,

--- a/web/marketing/tailwind.config.js
+++ b/web/marketing/tailwind.config.js
@@ -3,7 +3,7 @@ import brandPreset from "@regenfass/brand/tailwind.preset.cjs";
 /** @type {import('tailwindcss').Config} */
 export default {
   presets: [brandPreset],
-  darkMode: "class",
+  darkMode: ["selector", ':is(.dark, [data-kb-theme="dark"])'],
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On first load with system dark mode, the marketing site mixed light chrome (white header/sections, invisible nav) with dark hero/cards.

**Cause:** Kobalte only sets `data-kb-theme`, while Tailwind `dark:` utilities require `.dark`. Marketing never applied `.dark` on boot (unlike the installer IIFE), so token-based pieces went dark while body/header `dark:` classes stayed light.

## Fix

- Shared `initColorMode()` in `@regenfass/brand` applies both `.dark` and `data-kb-theme` from `kb-color-mode` / legacy `theme` / system preference
- Blocking head script in marketing, docs, brand-showcase, and installer `index.html` to avoid FOUC
- Call `initColorMode()` from each app entry
- Tailwind `darkMode` selector matches `:is(.dark, [data-kb-theme="dark"])`
- `ButtonModeToggle` persists both storage keys and keeps `.dark` synced via `createEffect`

## Merge conflict resolution

Merged latest `main` (DE/EN i18n #27). Both conflicts were simple combine-both-sides:

- `ButtonModeToggle.tsx`: keep `useBrandT` aria-label **and** `applyColorMode` / `persistColorMode`
- `marketing/index.html`: keep hreflang/canonical `/en` **and** theme bootstrap script

No complicated / conflicting-intent leftovers.

## Test plan

- [x] `pnpm test` (540 tests)
- [x] `pnpm build:marketing` / `pnpm build:installer`
- [ ] Hard-refresh marketing with OS dark mode: header, body, and sections should be dark; nav/toggle readable
- [ ] Toggle theme: both modes stay consistent after reload

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed4bf980-fbac-44cf-9597-e40422c50c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed4bf980-fbac-44cf-9597-e40422c50c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

