### PR TITLE
fix(brand): improve secondary button light-mode contrast

### DIFF
--- a/web/brand/src/components/atoms/ButtonAction.tsx
+++ b/web/brand/src/components/atoms/ButtonAction.tsx
@@ -29,7 +29,7 @@ export const ButtonAction: Component<ActionButtonProps> = (props) => {
       class={cn(
         isPrimary()
           ? "bg-blue-600 hover:bg-blue-700 text-white"
-          : "border-gray-300 text-gray-700 hover:bg-gray-50",
+          : "border-secondary bg-background text-secondary hover:bg-secondary/10 hover:text-secondary active:bg-secondary/15 data-[pressed]:bg-secondary/15",
         local.class,
       )}
     >
@@ -38,7 +38,7 @@ export const ButtonAction: Component<ActionButtonProps> = (props) => {
           size="sm" 
           class={cn(
             "-ml-1 mr-3",
-            isPrimary() ? "text-white" : "text-gray-500",
+            isPrimary() ? "text-white" : "text-secondary",
           )}
         />
       )}

--- a/web/brand/src/components/atoms/ButtonSecondary.tsx
+++ b/web/brand/src/components/atoms/ButtonSecondary.tsx
@@ -16,10 +16,14 @@ const ButtonSecondary: Component<SecondaryButtonProps> = (props) => {
       {...rest}
       variant="outline"
       disabled={local.loading || local.disabled}
-      class={cn("border-gray-300 text-gray-700 hover:bg-gray-50", local.class)}
+      class={cn(
+        // Brand teal outline — readable on light hero surfaces and dark chrome
+        "border-secondary bg-background text-secondary hover:bg-secondary/10 hover:text-secondary active:bg-secondary/15 data-[pressed]:bg-secondary/15",
+        local.class,
+      )}
     >
       {local.loading && (
-        <Spinner size="sm" class="-ml-1 mr-3 text-gray-500" />
+        <Spinner size="sm" class="-ml-1 mr-3 text-secondary" />
       )}
       {local.children}
     </Button>

--- a/web/brand/src/styles.css
+++ b/web/brand/src/styles.css
@@ -18,7 +18,8 @@
     --primary-foreground: 210 40% 98%;
 
     --secondary: 171  91%  36%;
-    --secondary-foreground: 171 100% 89%;
+    /* Near-white on teal — same-hue mint failed ~3:1 in light mode */
+    --secondary-foreground: 0 0% 100%;
 
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
@@ -58,7 +59,8 @@
     --primary-foreground: 0 0% 80%;
 
     --secondary: 171 91% 36%;
-    --secondary-foreground: 171 100% 9%;
+    /* Keep light label on teal so filled secondary stays readable in dark */
+    --secondary-foreground: 0 0% 100%;
 
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;

--- a/web/installer/docs/components/molecules/secondary-button.md
+++ b/web/installer/docs/components/molecules/secondary-button.md
@@ -23,11 +23,11 @@ import { ButtonSecondary } from '@/components/forms/ButtonSecondary';
 ## Design notes
 
 - Built on the base Button component with outline variant
-- Custom styling with gray border and text for secondary actions
+- Uses brand `secondary` tokens (teal border and label) for readable contrast in light and dark mode
 - Loading state shows animated spinner icon with proper spacing
 - Button is automatically disabled when loading is true
-- Spinner uses gray-500 color to match secondary button styling
-- Hover state provides subtle gray background feedback
+- Spinner uses `text-secondary` to match the outline label
+- Hover state provides a light secondary tint (`hover:bg-secondary/10`)
 - Loading spinner positioned with consistent spacing using Tailwind classes
 - Maintains accessibility with proper disabled state handling
-- Perfect for cancel, back, or other secondary actions in forms
+- Perfect for cancel, back, docs CTAs, or other secondary actions in forms

--- a/web/installer/tests/components/atoms/ButtonAction.test.tsx
+++ b/web/installer/tests/components/atoms/ButtonAction.test.tsx
@@ -30,8 +30,8 @@ describe("ButtonAction", () => {
   it("applies secondary styling", () => {
     const { container } = render(() => <ButtonAction type="secondary">Secondary</ButtonAction>);
     const button = container.querySelector("button");
-    expect(button).toHaveClass("border-gray-300");
-    expect(button).toHaveClass("text-gray-700");
+    expect(button).toHaveClass("border-secondary");
+    expect(button).toHaveClass("text-secondary");
   });
 
   it("shows loading spinner when loading is true", () => {
@@ -75,7 +75,7 @@ describe("ButtonAction", () => {
       </ButtonAction>
     ));
     const spinner = container.querySelector("svg.animate-spin");
-    expect(spinner).toHaveClass("text-gray-500");
+    expect(spinner).toHaveClass("text-secondary");
   });
 
   it("handles nativeType prop as submit", () => {

--- a/web/installer/tests/components/atoms/ButtonSecondary.test.tsx
+++ b/web/installer/tests/components/atoms/ButtonSecondary.test.tsx
@@ -14,12 +14,12 @@ describe("ButtonSecondary", () => {
     expect(screen.getByText("Secondary Button")).toBeInTheDocument();
   });
 
-  it("applies secondary gray styling", () => {
+  it("applies secondary brand outline styling", () => {
     const { container } = render(() => <ButtonSecondary>Secondary</ButtonSecondary>);
     const button = container.querySelector("button");
-    expect(button).toHaveClass("border-gray-300");
-    expect(button).toHaveClass("text-gray-700");
-    expect(button).toHaveClass("hover:bg-gray-50");
+    expect(button).toHaveClass("border-secondary");
+    expect(button).toHaveClass("text-secondary");
+    expect(button).toHaveClass("hover:bg-secondary/10");
   });
 
   it("applies outline variant", () => {
@@ -59,7 +59,7 @@ describe("ButtonSecondary", () => {
   it("shows spinner with correct styling when loading", () => {
     const { container } = render(() => <ButtonSecondary loading>Loading</ButtonSecondary>);
     const spinner = container.querySelector("svg.animate-spin");
-    expect(spinner).toHaveClass("text-gray-500");
+    expect(spinner).toHaveClass("text-secondary");
     expect(spinner).toHaveClass("-ml-1");
     expect(spinner).toHaveClass("mr-3");
     expect(spinner).toHaveClass("size-3");
@@ -76,7 +76,7 @@ describe("ButtonSecondary", () => {
     const { container } = render(() => <ButtonSecondary class="custom-class">Custom</ButtonSecondary>);
     const button = container.querySelector("button");
     expect(button).toHaveClass("custom-class");
-    expect(button).toHaveClass("border-gray-300");
+    expect(button).toHaveClass("border-secondary");
   });
 
   it("handles click events", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The marketing **Docs lesen** CTA (`ButtonSecondary`) used hardcoded gray Tailwind classes (`border-gray-300`, `text-gray-700`, `hover:bg-gray-50`). On the light hero surface those neutrals read weak next to the sky primary and ignore brand tokens.

Also tightened `--secondary-foreground` in light (and dark) mode: the previous same-hue mint/near-black labels on teal sat around ~3:1 and failed readable filled-secondary contrast.

## Changes

- `ButtonSecondary` / secondary `ButtonAction`: teal outline via `border-secondary` + `text-secondary`, light tint hover
- `--secondary-foreground` → white in light and dark for filled secondary surfaces
- Tests + component design notes updated

## Test plan

- [x] `vitest` for `ButtonSecondary` + `ButtonAction` (29 tests)
- [ ] Marketing hero in light mode: **Docs lesen** border/label clearly readable next to **Loslegen**
- [ ] Toggle dark mode: secondary outline still readable
- [ ] Brand showcase secondary button spot-check
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b1b1423-ce4b-48aa-9abc-9dfe7837eb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b1b1423-ce4b-48aa-9abc-9dfe7837eb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

